### PR TITLE
Print syntax errors when they exist. 

### DIFF
--- a/src/main/java/pikaparser/grammar/MetaGrammar.java
+++ b/src/main/java/pikaparser/grammar/MetaGrammar.java
@@ -416,8 +416,9 @@ public class MetaGrammar {
         //        }
 
         var syntaxErrors = memoTable.getSyntaxErrors(
-                new String[] { GRAMMAR, RULE, CLAUSE + "[" + clauseTypeToPrecedence.get(First.class) + "]" });
-        if (syntaxErrors.isEmpty()) {
+            GRAMMAR, RULE, CLAUSE + "[" + clauseTypeToPrecedence.get(First.class) + "]"
+        );
+        if (! syntaxErrors.isEmpty()) {
             ParserInfo.printSyntaxErrors(syntaxErrors);
         }
 


### PR DESCRIPTION
I'm pretty sure this is correct, since ParserInfo.printSyntaxErrors has an explicit if statement where it doesn't do anything if the collection of syntax errors is empty.

(Also, my IDE reminds me that since getSyntaxErrors is varargs, it doesn't need an array created to be passed as a parameter.)