### PR TITLE
Java parsing test

### DIFF
--- a/src/test/java/pikaparser/EndToEndTest.java
+++ b/src/test/java/pikaparser/EndToEndTest.java
@@ -31,8 +31,12 @@ package pikaparser;
 
 import org.junit.Test;
 import pikaparser.clause.Clause;
+import pikaparser.clause.nonterminal.First;
+import pikaparser.grammar.Grammar;
 import pikaparser.grammar.MetaGrammar;
 import pikaparser.memotable.Match;
+import pikaparser.memotable.MemoTable;
+import pikaparser.parser.utils.ParserInfo;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -61,11 +65,11 @@ public class EndToEndTest {
         final var input = loadResourceFile("arithmetic.input");
         final var memoTable = grammar.parse(input);
 
-        /*
+
         final var topRuleName = "Program";
         final String[] recoveryRuleNames = { topRuleName, "Statement" };
         ParserInfo.printParseResult(topRuleName, memoTable, recoveryRuleNames, false);
-         */
+
 
         final var allClauses = memoTable.grammar.allClauses;
         assertThat(allClauses.size(), is(27));
@@ -99,5 +103,25 @@ public class EndToEndTest {
 
         final String subClauseString = firstSubclauseMatchOfLastMatch.getValue().toStringWithRuleNames();
         assertThat(subClauseString, is("Statement <- var:[a-z]+ '=' E ';' : 0+23"));
+    }
+
+    @Test
+    public void can_parse_java_example() throws IOException, URISyntaxException {
+        final var grammarSpec = loadResourceFile("Java.1.8.peg");
+        final var grammar = MetaGrammar.parse(grammarSpec);
+
+        final var input = loadResourceFile("MemoTable.java");
+        final var memoTable = grammar.parse(input);
+
+        final var topRuleName = "Compilation";
+        final String[] recoveryRuleNames = { topRuleName, "CompilationUnit" };
+
+        // Huge output; only do this if you have a big buffer
+        // ParserInfo.printParseResult(topRuleName, memoTable, recoveryRuleNames, false);
+
+        final var syntaxErrors = memoTable.getSyntaxErrors(recoveryRuleNames);
+        if (! syntaxErrors.isEmpty()) {
+            ParserInfo.printSyntaxErrors(syntaxErrors);
+        }
     }
 }

--- a/src/test/resources/Java.1.8.original_without_comments.peg
+++ b/src/test/resources/Java.1.8.original_without_comments.peg
@@ -1,0 +1,976 @@
+Compilation
+    <- Spacing CompilationUnit SUB? EOT;
+
+SUB <- "\u001a" ;
+EOT <- !_ ;
+
+Spacing
+    <- ( [ \t\r\n\u000C]+
+      / "/*" _*+ "*/"
+      / "//" _*+ [\r\n]
+      )* ;
+
+Identifier  <- !Keyword Letter LetterOrDigit* Spacing ;
+
+Letter <- [a-z] / [A-Z] / [_$] ;
+
+LetterOrDigit <- [a-z] / [A-Z] / [0-9] / [_$] ;
+
+Keyword
+    <- ( "abstract"
+      / "assert"
+      / "boolean"
+      / "break"
+      / "byte"
+      / "case"
+      / "catch"
+      / "char"
+      / "class"
+      / "const"
+      / "continue"
+      / "default"
+      / "double"
+      / "do"
+      / "else"
+      / "enum"
+      / "extends"
+      / "false"
+      / "finally"
+      / "final"
+      / "float"
+      / "for"
+      / "goto"
+      / "if"
+      / "implements"
+      / "import"
+      / "interface"
+      / "int"
+      / "instanceof"
+      / "long"
+      / "native"
+      / "new"
+      / "null"
+      / "package"
+      / "private"
+      / "protected"
+      / "public"
+      / "return"
+      / "short"
+      / "static"
+      / "strictfp"
+      / "super"
+      / "switch"
+      / "synchronized"
+      / "this"
+      / "throws"
+      / "throw"
+      / "transient"
+      / "true"
+      / "try"
+      / "void"
+      / "volatile"
+      / "while"
+      ) !LetterOrDigit
+    ;
+
+ABSTRACT     <- "abstract"     !LetterOrDigit Spacing ;
+ASSERT       <- "assert"       !LetterOrDigit Spacing ;
+BOOLEAN      <- "boolean"      !LetterOrDigit Spacing ;
+BREAK        <- "break"        !LetterOrDigit Spacing ;
+BYTE         <- "byte"         !LetterOrDigit Spacing ;
+CASE         <- "case"         !LetterOrDigit Spacing ;
+CATCH        <- "catch"        !LetterOrDigit Spacing ;
+CHAR         <- "char"         !LetterOrDigit Spacing ;
+CLASS        <- "class"        !LetterOrDigit Spacing ;
+CONTINUE     <- "continue"     !LetterOrDigit Spacing ;
+DEFAULT      <- "default"      !LetterOrDigit Spacing ;
+DOUBLE       <- "double"       !LetterOrDigit Spacing ;
+DO           <- "do"           !LetterOrDigit Spacing ;
+ELSE         <- "else"         !LetterOrDigit Spacing ;
+ENUM         <- "enum"         !LetterOrDigit Spacing ;
+EXTENDS      <- "extends"      !LetterOrDigit Spacing ;
+FALSE        <- "false"        !LetterOrDigit Spacing ;
+FINALLY      <- "finally"      !LetterOrDigit Spacing ;
+FINAL        <- "final"        !LetterOrDigit Spacing ;
+FLOAT        <- "float"        !LetterOrDigit Spacing ;
+FOR          <- "for"          !LetterOrDigit Spacing ;
+IF           <- "if"           !LetterOrDigit Spacing ;
+IMPLEMENTS   <- "implements"   !LetterOrDigit Spacing ;
+IMPORT       <- "import"       !LetterOrDigit Spacing ;
+INTERFACE    <- "interface"    !LetterOrDigit Spacing ;
+INT          <- "int"          !LetterOrDigit Spacing ;
+INSTANCEOF   <- "instanceof"   !LetterOrDigit Spacing ;
+LONG         <- "long"         !LetterOrDigit Spacing ;
+NATIVE       <- "native"       !LetterOrDigit Spacing ;
+NEW          <- "new"          !LetterOrDigit Spacing ;
+NULL         <- "null"         !LetterOrDigit Spacing ;
+PACKAGE      <- "package"      !LetterOrDigit Spacing ;
+PRIVATE      <- "private"      !LetterOrDigit Spacing ;
+PROTECTED    <- "protected"    !LetterOrDigit Spacing ;
+PUBLIC       <- "public"       !LetterOrDigit Spacing ;
+RETURN       <- "return"       !LetterOrDigit Spacing ;
+SHORT        <- "short"        !LetterOrDigit Spacing ;
+STATIC       <- "static"       !LetterOrDigit Spacing ;
+STRICTFP     <- "strictfp"     !LetterOrDigit Spacing ;
+SUPER        <- "super"        !LetterOrDigit Spacing ;
+SWITCH       <- "switch"       !LetterOrDigit Spacing ;
+SYNCHRONIZED <- "synchronized" !LetterOrDigit Spacing ;
+THIS         <- "this"         !LetterOrDigit Spacing ;
+THROWS       <- "throws"       !LetterOrDigit Spacing ;
+THROW        <- "throw"        !LetterOrDigit Spacing ;
+TRANSIENT    <- "transient"    !LetterOrDigit Spacing ;
+TRUE         <- "true"         !LetterOrDigit Spacing ;
+TRY          <- "try"          !LetterOrDigit Spacing ;
+VOID         <- "void"         !LetterOrDigit Spacing ;
+VOLATILE     <- "volatile"     !LetterOrDigit Spacing ;
+WHILE        <- "while"        !LetterOrDigit Spacing ;
+
+Literal
+    <- FloatLiteral
+    / IntegerLiteral
+    / BooleanLiteral
+    / CharLiteral
+    / StringLiteral
+    / NullLiteral
+    ;
+
+IntegerLiteral
+    <- ( HexNumeral
+      / BinaryNumeral
+      / OctalNumeral
+      / DecimalNumeral
+      ) [lL]? Spacing
+    ;
+
+DecimalNumeral
+    <- "0"
+    / [1-9]([_]*[0-9])*
+    ;
+
+HexNumeral
+    <- ("0x" / "0X") HexDigits ;
+
+OctalNumeral
+    <- "0" ([_]*[0-7])+ ;
+
+BinaryNumeral
+    <- ("0b" / "0B") [01]([_]*[01])* ;
+
+FloatLiteral
+    <- ( HexadecimalFloatingPointLiteral
+      / DecimalFloatingPointLiteral
+      ) Spacing
+    ;
+
+DecimalFloatingPointLiteral
+    <- Digits "." Digits?  Exponent? [fFdD]?
+    / "." Digits Exponent? [fFdD]?
+    / Digits Exponent [fFdD]?
+    / Digits Exponent? [fFdD]
+    ;
+
+Exponent
+    <- [eE] [+\-]? Digits ;
+
+HexadecimalFloatingPointLiteral
+    <- HexSignificand BinaryExponent [fFdD]? ;
+
+HexSignificand
+    <- ("0x" / "0X") HexDigits? "." HexDigits
+    / HexNumeral "."?
+    ;
+
+HexDigits
+    <- HexDigit ([_]*HexDigit)* ;
+
+HexDigit
+    <- [a-f] / [A-F] / [0-9] ;
+
+BinaryExponent
+    <- [pP] [+\-]? Digits ;
+
+Digits
+    <- [0-9]([_]*[0-9])* ;
+
+BooleanLiteral
+    <- TRUE
+    / FALSE
+    ;
+
+CharLiteral
+    <- "'" (Escape / !['\\\n\r] _) "'" Spacing
+    ;
+
+StringLiteral
+    <- "\"" (Escape / !["\\\n\r] _)* "\"" Spacing
+    ;
+
+Escape
+    <- "\\" ([btnfr"'\\] / OctalEscape / UnicodeEscape)
+    ;
+
+OctalEscape
+    <- [0-3][0-7][0-7]
+    / [0-7][0-7]
+    / [0-7]
+    ;
+
+UnicodeEscape
+    <- "u"+ HexDigit HexDigit HexDigit HexDigit ;
+
+NullLiteral <- NULL ;
+
+AT              <-   "@"       Spacing ;
+COLONCOLON      <-   "::"      Spacing ;
+COMMA           <-   ","       Spacing ;
+DOT             <-   "."       Spacing ;
+ELLIPSIS        <-   "..."     Spacing ;
+LPAR            <-   "("       Spacing ;
+LBRK            <-   "["       Spacing ;
+RBRK            <-   "]"       Spacing ;
+RPAR            <-   ")"       Spacing ;
+LWING           <-   "{"       Spacing ;
+RWING           <-   "}"       Spacing ;
+SEMI            <-   ";"       Spacing ;
+
+AND             <-   "&"![=&]  Spacing ;
+ANDAND          <-   "&&"      Spacing ;
+ANDEQU          <-   "&="      Spacing ;
+ARROW           <-   "->"      Spacing ;
+BANG            <-   "!" ![=]  Spacing ;
+BSR             <-   ">>>"![=] Spacing ;
+BSREQU          <-   ">>>="    Spacing ;
+COLON           <-   ":" ![:]  Spacing ;
+DEC             <-   "--"      Spacing ;
+DIV             <-   "/" ![=]  Spacing ;
+DIVEQU          <-   "/="      Spacing ;
+EQU             <-   "=" ![=]  Spacing ;
+EQUAL           <-   "=="      Spacing ;
+GE              <-   ">="      Spacing ;
+GT              <-   ">"![=>]  Spacing ;
+HAT             <-   "^"![=]   Spacing ;
+HATEQU          <-   "^="      Spacing ;
+INC             <-   "++"      Spacing ;
+LE              <-   "<="      Spacing ;
+LPOINT          <-   "<"       Spacing ;
+LT              <-   "<"![=<]  Spacing ;
+MINUS           <-   "-"![=\->]Spacing ;
+MINUSEQU        <-   "-="      Spacing ;
+MOD             <-   "%"![=]   Spacing ;
+MODEQU          <-   "%="      Spacing ;
+NOTEQUAL        <-   "!="      Spacing ;
+OR              <-   "|"![=|]  Spacing ;
+OREQU           <-   "|="      Spacing ;
+OROR            <-   "||"      Spacing ;
+PLUS            <-   "+"![=+]  Spacing ;
+PLUSEQU         <-   "+="      Spacing ;
+QUERY           <-   "?"       Spacing ;
+RPOINT          <-   ">"       Spacing ;
+SL              <-   "<<"![=]  Spacing ;
+SLEQU           <-   "<<="     Spacing ;
+SR              <-   ">>"![=>] Spacing ;
+SREQU           <-   ">>="     Spacing ;
+STAR            <-   "*"![=]   Spacing ;
+STAREQU         <-   "*="      Spacing ;
+TILDE           <-   "~"       Spacing ;
+
+BasicType
+    <- BYTE
+    / SHORT
+    / INT
+    / LONG
+    / CHAR
+    / FLOAT
+    / DOUBLE
+    / BOOLEAN
+    ;
+
+PrimitiveType
+    <- Annotation* BasicType ;
+
+ReferenceType
+    <- PrimitiveType Dim+
+    / ClassType Dim*
+    ;
+
+ClassType
+    <- Annotation* Identifier TypeArguments?
+          (DOT Annotation* Identifier TypeArguments?)* ;
+
+Type
+    <- PrimitiveType
+    / ClassType
+    ;
+
+ArrayType
+    <- PrimitiveType Dim+
+    / ClassType Dim+
+    ;
+
+TypeVariable
+    <- Annotation* Identifier ;
+
+Dim
+    <- Annotation* LBRK RBRK ;
+
+TypeParameter
+    <- TypeParameterModifier* Identifier TypeBound? ;
+
+TypeParameterModifier
+    <- Annotation ;
+
+TypeBound
+    <- EXTENDS (ClassType AdditionalBound* / TypeVariable) ;
+
+AdditionalBound
+    <- AND ClassType ;
+
+TypeArguments
+    <- LPOINT TypeArgumentList RPOINT ;
+
+TypeArgumentList
+    <- TypeArgument (COMMA TypeArgument)* ;
+
+TypeArgument
+    <- ReferenceType
+    / Wildcard
+    ;
+
+Wildcard
+    <- Annotation* QUERY WildcardBounds? ;
+
+WildcardBounds
+    <- EXTENDS ReferenceType
+    / SUPER ReferenceType
+    ;
+QualIdent
+    <- Identifier (DOT Identifier)* ;
+
+CompilationUnit
+    <- PackageDeclaration? ImportDeclaration* TypeDeclaration* ;
+
+PackageDeclaration
+    <- PackageModifier* PACKAGE Identifier (DOT Identifier)* SEMI ;
+
+PackageModifier
+    <- Annotation ;
+
+ImportDeclaration
+    <- IMPORT STATIC? QualIdent (DOT STAR)? SEMI
+    / SEMI
+    ;
+
+TypeDeclaration
+    <- ClassDeclaration
+    / InterfaceDeclaration
+    / SEMI
+    ;
+
+ClassDeclaration
+    <- NormalClassDeclaration
+    / EnumDeclaration
+    ;
+
+NormalClassDeclaration
+    <- ClassModifier* CLASS Identifier TypeParameters?
+          Superclass? Superinterfaces? ClassBody
+    ;
+
+ClassModifier
+    <- Annotation
+    / PUBLIC
+    / PROTECTED
+    / PRIVATE
+    / ABSTRACT
+    / STATIC
+    / FINAL
+    / STRICTFP
+    ;
+
+TypeParameters
+    <- LPOINT TypeParameterList RPOINT ;
+
+TypeParameterList
+    <- TypeParameter (COMMA TypeParameter)* ;
+
+Superclass
+    <- EXTENDS ClassType ;
+
+Superinterfaces
+    <- IMPLEMENTS InterfaceTypeList ;
+
+InterfaceTypeList
+    <- ClassType (COMMA ClassType)* ;
+
+ClassBody
+    <- LWING ClassBodyDeclaration* RWING ;
+
+ClassBodyDeclaration
+    <- ClassMemberDeclaration
+    / InstanceInitializer
+    / StaticInitializer
+    / ConstructorDeclaration
+    ;
+
+ClassMemberDeclaration
+    <- FieldDeclaration
+    / MethodDeclaration
+    / ClassDeclaration
+    / InterfaceDeclaration
+    / SEMI
+    ;
+
+FieldDeclaration
+    <- FieldModifier* UnannType VariableDeclaratorList SEMI ;
+
+VariableDeclaratorList
+    <- VariableDeclarator (COMMA VariableDeclarator)* ;
+
+VariableDeclarator
+    <- VariableDeclaratorId (EQU VariableInitializer)? ;
+
+VariableDeclaratorId
+    <- Identifier Dim* ;
+
+VariableInitializer
+    <- Expression
+    / ArrayInitializer
+    ;
+
+UnannClassType
+    <- Identifier TypeArguments?
+          (DOT Annotation* Identifier TypeArguments?)*  ;
+
+UnannType
+    <- BasicType Dim*
+    / UnannClassType Dim*
+    ;
+
+FieldModifier
+    <- Annotation
+    / PUBLIC
+    / PROTECTED
+    / PRIVATE
+    / STATIC
+    / FINAL
+    / TRANSIENT
+    / VOLATILE
+    ;
+
+MethodDeclaration
+    <- MethodModifier* MethodHeader MethodBody ;
+
+MethodHeader
+    <- Result MethodDeclarator Throws?
+    / TypeParameters Annotation* Result MethodDeclarator Throws?
+    ;
+
+MethodDeclarator
+    <- Identifier LPAR FormalParameterList? RPAR Dim* ;
+
+FormalParameterList
+    <- (ReceiverParameter / FormalParameter)(COMMA FormalParameter)* ;
+
+FormalParameter
+    <- VariableModifier* UnannType VariableDeclaratorId
+    / VariableModifier* UnannType Annotation* ELLIPSIS VariableDeclaratorId !COMMA
+    ;
+
+VariableModifier
+    <- Annotation
+    / FINAL
+    ;
+
+ReceiverParameter
+    <- VariableModifier* UnannType (Identifier DOT)? THIS ;
+
+Result
+    <- UnannType
+    / VOID
+    ;
+
+MethodModifier
+    <- Annotation
+    / PUBLIC
+    / PROTECTED
+    / PRIVATE
+    / ABSTRACT
+    / STATIC
+    / FINAL
+    / SYNCHRONIZED
+    / NATIVE
+    / STRICTFP
+    ;
+
+Throws
+    <- THROWS ExceptionTypeList ;
+
+ExceptionTypeList
+    <- ExceptionType (COMMA ExceptionType)* ;
+
+ExceptionType
+    <- ClassType
+    / TypeVariable
+    ;
+
+MethodBody
+    <- Block
+    / SEMI
+    ;
+
+InstanceInitializer
+    <- Block ;
+
+StaticInitializer
+    <- STATIC Block ;
+
+ConstructorDeclaration
+    <- ConstructorModifier* ConstructorDeclarator Throws? ConstructorBody ;
+
+ConstructorDeclarator
+    <- TypeParameters? Identifier LPAR FormalParameterList? RPAR ;
+
+ConstructorModifier
+    <- Annotation
+    / PUBLIC
+    / PROTECTED
+    / PRIVATE
+    ;
+
+ConstructorBody
+    <- LWING ExplicitConstructorInvocation? BlockStatements? RWING ;
+
+ExplicitConstructorInvocation
+    <- TypeArguments? THIS Arguments SEMI
+    / TypeArguments? SUPER Arguments SEMI
+    / Primary DOT TypeArguments? SUPER Arguments SEMI
+    / QualIdent DOT TypeArguments? SUPER Arguments SEMI
+    ;
+
+EnumDeclaration
+    <- ClassModifier* ENUM Identifier Superinterfaces? EnumBody ;
+
+EnumBody
+    <- LWING EnumConstantList? COMMA? EnumBodyDeclarations? RWING ;
+
+EnumConstantList
+    <- EnumConstant (COMMA EnumConstant)* ;
+
+EnumConstant
+    <- EnumConstantModifier* Identifier Arguments? ClassBody? ;
+
+EnumConstantModifier
+    <- Annotation ;
+
+EnumBodyDeclarations
+    <- SEMI ClassBodyDeclaration* ;
+
+InterfaceDeclaration
+    <- NormalInterfaceDeclaration
+    / AnnotationTypeDeclaration
+    ;
+
+NormalInterfaceDeclaration
+    <- InterfaceModifier* INTERFACE Identifier TypeParameters?
+          ExtendsInterfaces? InterfaceBody ;
+
+InterfaceModifier
+    <- Annotation
+    / PUBLIC
+    / PROTECTED
+    / PRIVATE
+    / ABSTRACT
+    / STATIC
+    / STRICTFP
+    ;
+
+ExtendsInterfaces
+    <- EXTENDS InterfaceTypeList ;
+
+InterfaceBody
+    <- LWING InterfaceMemberDeclaration* RWING ;
+
+InterfaceMemberDeclaration
+    <- ConstantDeclaration
+    / InterfaceMethodDeclaration
+    / ClassDeclaration
+    / InterfaceDeclaration
+    / SEMI
+    ;
+
+ConstantDeclaration
+    <- ConstantModifier* UnannType VariableDeclaratorList SEMI ;
+
+ConstantModifier
+    <- Annotation
+    / PUBLIC
+    / STATIC
+    / FINAL
+    ;
+
+InterfaceMethodDeclaration
+    <- InterfaceMethodModifier* MethodHeader MethodBody ;
+
+InterfaceMethodModifier
+    <- Annotation
+    / PUBLIC
+    / ABSTRACT
+    / DEFAULT
+    / STATIC
+    / STRICTFP
+    ;
+
+AnnotationTypeDeclaration
+    <- InterfaceModifier* AT INTERFACE Identifier AnnotationTypeBody ;
+
+AnnotationTypeBody
+    <- LWING AnnotationTypeMemberDeclaration* RWING ;
+
+AnnotationTypeMemberDeclaration
+    <- AnnotationTypeElementDeclaration
+    / ConstantDeclaration
+    / ClassDeclaration
+    / InterfaceDeclaration
+    / SEMI
+    ;
+
+AnnotationTypeElementDeclaration
+    <- AnnotationTypeElementModifier* UnannType Identifier LPAR RPAR Dim*
+         DefaultValue? SEMI ;
+
+AnnotationTypeElementModifier
+    <- Annotation
+    / PUBLIC
+    / ABSTRACT
+    ;
+
+DefaultValue
+    <- DEFAULT ElementValue ;
+
+Annotation
+    <- AT
+      ( NormalAnnotation
+      / SingleElementAnnotation
+      / MarkerAnnotation
+      )
+    ;
+
+NormalAnnotation
+    <- QualIdent LPAR ElementValuePairList* RPAR ;
+
+ElementValuePairList
+    <- ElementValuePair (COMMA ElementValuePair)* ;
+
+ElementValuePair
+    <- Identifier EQU ElementValue ;
+
+ElementValue
+    <- ConditionalExpression
+    / ElementValueArrayInitializer
+    / Annotation
+    ;
+
+ElementValueArrayInitializer
+    <- LWING ElementValueList? COMMA? RWING ;
+
+ElementValueList
+    <- ElementValue (COMMA ElementValue)* ;
+
+MarkerAnnotation
+    <- QualIdent ;
+
+SingleElementAnnotation
+    <- QualIdent LPAR ElementValue RPAR ;
+
+ArrayInitializer
+    <- LWING VariableInitializerList? COMMA? RWING ;
+
+VariableInitializerList
+    <- VariableInitializer (COMMA VariableInitializer)* ;
+Block
+    <- LWING BlockStatements? RWING ;
+
+BlockStatements
+    <- BlockStatement BlockStatement* ;
+
+BlockStatement
+    <- LocalVariableDeclarationStatement
+    / ClassDeclaration
+    / Statement
+    ;
+
+LocalVariableDeclarationStatement
+    <- LocalVariableDeclaration SEMI ;
+
+LocalVariableDeclaration
+    <- VariableModifier* UnannType VariableDeclaratorList ;
+
+Statement
+    <- Block
+    / IF ParExpression Statement (ELSE Statement)?
+    / BasicForStatement
+    / EnhancedForStatement
+    / WHILE ParExpression Statement
+    / DO Statement WHILE ParExpression SEMI
+    / TryStatement
+    / SWITCH ParExpression SwitchBlock
+    / SYNCHRONIZED ParExpression Block
+    / RETURN Expression? SEMI
+    / THROW Expression SEMI
+    / BREAK Identifier? SEMI
+    / CONTINUE Identifier? SEMI
+    / ASSERT Expression (COLON Expression)? SEMI
+    / SEMI
+    / StatementExpression SEMI
+    / Identifier COLON Statement
+    ;
+
+StatementExpression
+    <- Assignment
+    / (INC / DEC)(Primary / QualIdent)
+    / (Primary / QualIdent)(INC / DEC)
+    / Primary
+    ;
+
+SwitchBlock
+    <- LWING SwitchBlockStatementGroup* SwitchLabel* RWING ;
+
+SwitchBlockStatementGroup
+    <- SwitchLabels BlockStatements ;
+
+SwitchLabels
+    <- SwitchLabel SwitchLabel* ;
+
+SwitchLabel
+    <- CASE (ConstantExpression / EnumConstantName) COLON
+    / DEFAULT COLON
+    ;
+
+EnumConstantName
+    <- Identifier ;
+
+BasicForStatement
+    <- FOR LPAR ForInit? SEMI Expression? SEMI ForUpdate? RPAR Statement ;
+
+ForInit
+    <- LocalVariableDeclaration
+    / StatementExpressionList
+    ;
+
+ForUpdate
+    <- StatementExpressionList ;
+
+StatementExpressionList
+    <- StatementExpression (COMMA  StatementExpression)* ;
+
+EnhancedForStatement
+    <- FOR LPAR VariableModifier* UnannType VariableDeclaratorId COLON
+          Expression RPAR Statement ;
+
+TryStatement
+    <- TRY
+      ( Block (CatchClause* Finally / CatchClause+)
+      / ResourceSpecification Block CatchClause* Finally?
+      )
+    ;
+
+CatchClause
+    <- CATCH LPAR CatchFormalParameter RPAR Block ;
+
+CatchFormalParameter
+    <- VariableModifier* CatchType VariableDeclaratorId ;
+
+CatchType
+    <- UnannClassType (OR ClassType)* ;
+
+Finally
+    <- FINALLY Block ;
+
+ResourceSpecification
+    <- LPAR ResourceList SEMI? RPAR ;
+
+ResourceList
+    <- Resource (SEMI Resource)* ;
+
+Resource
+    <- VariableModifier* UnannType VariableDeclaratorId EQU Expression ;
+
+Expression
+    <- LambdaExpression
+    / AssignmentExpression
+    ;
+
+Primary
+    <- PrimaryBase PrimaryRest* ;
+
+PrimaryBase
+    <- THIS
+    / Literal
+    / ParExpression
+    / SUPER
+      ( DOT TypeArguments? Identifier Arguments
+      / DOT Identifier
+      / COLONCOLON TypeArguments? Identifier
+      )
+    / NEW
+      ( ClassCreator
+      / ArrayCreator
+      )
+    / QualIdent
+      ( LBRK Expression RBRK
+      / Arguments
+      / DOT
+        ( THIS
+        / NEW ClassCreator
+        / TypeArguments Identifier Arguments
+        / SUPER DOT TypeArguments? Identifier Arguments
+        / SUPER DOT Identifier
+        / SUPER COLONCOLON TypeArguments? Identifier
+        )
+      / (LBRK RBRK)* DOT CLASS
+      / COLONCOLON TypeArguments? Identifier
+      )
+    / VOID DOT CLASS
+    / BasicType (LBRK RBRK)* DOT CLASS
+    / ReferenceType COLONCOLON TypeArguments? Identifier
+    / ClassType COLONCOLON TypeArguments? NEW
+    / ArrayType COLONCOLON NEW
+    ;
+
+PrimaryRest
+    <- DOT
+      ( TypeArguments? Identifier Arguments
+      / Identifier
+      / NEW ClassCreator
+      )
+    / LBRK Expression RBRK
+    / COLONCOLON TypeArguments? Identifier
+    ;
+
+ParExpression
+    <- LPAR Expression RPAR ;
+
+ClassCreator
+    <- TypeArguments? Annotation* ClassTypeWithDiamond
+          Arguments ClassBody? ;
+
+ClassTypeWithDiamond
+    <- Annotation* Identifier TypeArgumentsOrDiamond?
+          (DOT Annotation* Identifier TypeArgumentsOrDiamond?)* ;
+
+TypeArgumentsOrDiamond
+    <- TypeArguments
+    / LPOINT RPOINT !DOT
+    ;
+
+ArrayCreator
+    <- Type DimExpr+ Dim*
+    / Type Dim+ ArrayInitializer
+    ;
+
+DimExpr
+    <- Annotation* LBRK Expression RBRK ;
+
+
+Arguments
+    <- LPAR ArgumentList? RPAR ;
+
+ArgumentList
+    <- Expression (COMMA Expression)* ;
+
+UnaryExpression
+    <- (INC / DEC)(Primary / QualIdent)
+    / PLUS UnaryExpression
+    / MINUS UnaryExpression
+    / UnaryExpressionNotPlusMinus
+    ;
+
+UnaryExpressionNotPlusMinus
+    <- TILDE UnaryExpression
+    / BANG UnaryExpression
+    / CastExpression
+    / (Primary / QualIdent) (INC / DEC)?
+    ;
+
+CastExpression
+    <- LPAR PrimitiveType RPAR UnaryExpression
+    / LPAR ReferenceType AdditionalBound* RPAR LambdaExpression
+    / LPAR ReferenceType AdditionalBound* RPAR UnaryExpressionNotPlusMinus
+    ;
+
+InfixExpression
+    <- UnaryExpression
+          ((InfixOperator UnaryExpression) / (INSTANCEOF ReferenceType))* ;
+
+InfixOperator
+    <- OROR
+    / ANDAND
+    / OR
+    / HAT
+    / AND
+    / EQUAL
+    / NOTEQUAL
+    / LT
+    / GT
+    / LE
+    / GE
+    / SL
+    / SR
+    / BSR
+    / PLUS
+    / MINUS
+    / STAR
+    / DIV
+    / MOD
+    ;
+
+ConditionalExpression
+    <- InfixExpression (QUERY Expression COLON Expression)* ;
+
+AssignmentExpression
+    <- Assignment
+    / ConditionalExpression
+    ;
+
+Assignment
+    <- LeftHandSide AssignmentOperator Expression ;
+
+LeftHandSide
+    <- Primary
+    / QualIdent
+    ;
+
+AssignmentOperator
+    <- EQU
+    / STAREQU
+    / DIVEQU
+    / MODEQU
+    / PLUSEQU
+    / MINUSEQU
+    / SLEQU
+    / SREQU
+    / BSREQU
+    / ANDEQU
+    / HATEQU
+    / OREQU
+    ;
+
+LambdaExpression
+    <- LambdaParameters ARROW LambdaBody ;
+
+LambdaParameters
+    <- Identifier
+    / LPAR FormalParameterList? RPAR
+    / LPAR InferredFormalParameterList RPAR
+    ;
+
+InferredFormalParameterList
+    <- Identifier (COMMA Identifier)* ;
+
+LambdaBody
+    <- Expression
+    / Block
+    ;
+
+ConstantExpression
+    <- Expression ;

--- a/src/test/resources/Java.1.8.peg
+++ b/src/test/resources/Java.1.8.peg
@@ -1,0 +1,980 @@
+Compilation
+    <- Spacing CompilationUnit SUB? EOT;
+
+_ <- [ -~] ;
+SUB <- "\t" ;
+EOT <- !_ ;
+
+Star <- '*' ;
+NonCloseComment <- [^/] / !Star '/' ;
+
+Spacing
+    <- ( [ \t\r\n]+
+      / "/*" NonCloseComment* "*/"
+      / "//" [^\r\n]* [\r\n]
+      )* ;
+
+Identifier  <- !Keyword Letter LetterOrDigit* Spacing ;
+
+Letter <- [a-z] / [A-Z] / [_$] ;
+
+LetterOrDigit <- [a-z] / [A-Z] / [0-9] / [_$] ;
+
+Keyword
+    <- ( "abstract"
+      / "assert"
+      / "boolean"
+      / "break"
+      / "byte"
+      / "case"
+      / "catch"
+      / "char"
+      / "class"
+      / "const"
+      / "continue"
+      / "default"
+      / "double"
+      / "do"
+      / "else"
+      / "enum"
+      / "extends"
+      / "false"
+      / "finally"
+      / "final"
+      / "float"
+      / "for"
+      / "goto"
+      / "if"
+      / "implements"
+      / "import"
+      / "interface"
+      / "int"
+      / "instanceof"
+      / "long"
+      / "native"
+      / "new"
+      / "null"
+      / "package"
+      / "private"
+      / "protected"
+      / "public"
+      / "return"
+      / "short"
+      / "static"
+      / "strictfp"
+      / "super"
+      / "switch"
+      / "synchronized"
+      / "this"
+      / "throws"
+      / "throw"
+      / "transient"
+      / "true"
+      / "try"
+      / "void"
+      / "volatile"
+      / "while"
+      ) !LetterOrDigit
+    ;
+
+ABSTRACT     <- "abstract"     !LetterOrDigit Spacing ;
+ASSERT       <- "assert"       !LetterOrDigit Spacing ;
+BOOLEAN      <- "boolean"      !LetterOrDigit Spacing ;
+BREAK        <- "break"        !LetterOrDigit Spacing ;
+BYTE         <- "byte"         !LetterOrDigit Spacing ;
+CASE         <- "case"         !LetterOrDigit Spacing ;
+CATCH        <- "catch"        !LetterOrDigit Spacing ;
+CHAR         <- "char"         !LetterOrDigit Spacing ;
+CLASS        <- "class"        !LetterOrDigit Spacing ;
+CONTINUE     <- "continue"     !LetterOrDigit Spacing ;
+DEFAULT      <- "default"      !LetterOrDigit Spacing ;
+DOUBLE       <- "double"       !LetterOrDigit Spacing ;
+DO           <- "do"           !LetterOrDigit Spacing ;
+ELSE         <- "else"         !LetterOrDigit Spacing ;
+ENUM         <- "enum"         !LetterOrDigit Spacing ;
+EXTENDS      <- "extends"      !LetterOrDigit Spacing ;
+FALSE        <- "false"        !LetterOrDigit Spacing ;
+FINALLY      <- "finally"      !LetterOrDigit Spacing ;
+FINAL        <- "final"        !LetterOrDigit Spacing ;
+FLOAT        <- "float"        !LetterOrDigit Spacing ;
+FOR          <- "for"          !LetterOrDigit Spacing ;
+IF           <- "if"           !LetterOrDigit Spacing ;
+IMPLEMENTS   <- "implements"   !LetterOrDigit Spacing ;
+IMPORT       <- "import"       !LetterOrDigit Spacing ;
+INTERFACE    <- "interface"    !LetterOrDigit Spacing ;
+INT          <- "int"          !LetterOrDigit Spacing ;
+INSTANCEOF   <- "instanceof"   !LetterOrDigit Spacing ;
+LONG         <- "long"         !LetterOrDigit Spacing ;
+NATIVE       <- "native"       !LetterOrDigit Spacing ;
+NEW          <- "new"          !LetterOrDigit Spacing ;
+NULL         <- "null"         !LetterOrDigit Spacing ;
+PACKAGE      <- "package"      !LetterOrDigit Spacing ;
+PRIVATE      <- "private"      !LetterOrDigit Spacing ;
+PROTECTED    <- "protected"    !LetterOrDigit Spacing ;
+PUBLIC       <- "public"       !LetterOrDigit Spacing ;
+RETURN       <- "return"       !LetterOrDigit Spacing ;
+SHORT        <- "short"        !LetterOrDigit Spacing ;
+STATIC       <- "static"       !LetterOrDigit Spacing ;
+STRICTFP     <- "strictfp"     !LetterOrDigit Spacing ;
+SUPER        <- "super"        !LetterOrDigit Spacing ;
+SWITCH       <- "switch"       !LetterOrDigit Spacing ;
+SYNCHRONIZED <- "synchronized" !LetterOrDigit Spacing ;
+THIS         <- "this"         !LetterOrDigit Spacing ;
+THROWS       <- "throws"       !LetterOrDigit Spacing ;
+THROW        <- "throw"        !LetterOrDigit Spacing ;
+TRANSIENT    <- "transient"    !LetterOrDigit Spacing ;
+TRUE         <- "true"         !LetterOrDigit Spacing ;
+TRY          <- "try"          !LetterOrDigit Spacing ;
+VOID         <- "void"         !LetterOrDigit Spacing ;
+VOLATILE     <- "volatile"     !LetterOrDigit Spacing ;
+WHILE        <- "while"        !LetterOrDigit Spacing ;
+
+Literal
+    <- FloatLiteral
+    / IntegerLiteral
+    / BooleanLiteral
+    / CharLiteral
+    / StringLiteral
+    / NullLiteral
+    ;
+
+IntegerLiteral
+    <- ( HexNumeral
+      / BinaryNumeral
+      / OctalNumeral
+      / DecimalNumeral
+      ) [lL]? Spacing
+    ;
+
+DecimalNumeral
+    <- "0"
+    / [1-9]([_]*[0-9])*
+    ;
+
+HexNumeral
+    <- ("0x" / "0X") HexDigits ;
+
+OctalNumeral
+    <- "0" ([_]*[0-7])+ ;
+
+BinaryNumeral
+    <- ("0b" / "0B") [01]([_]*[01])* ;
+
+FloatLiteral
+    <- ( HexadecimalFloatingPointLiteral
+      / DecimalFloatingPointLiteral
+      ) Spacing
+    ;
+
+DecimalFloatingPointLiteral
+    <- Digits "." Digits?  Exponent? [fFdD]?
+    / "." Digits Exponent? [fFdD]?
+    / Digits Exponent [fFdD]?
+    / Digits Exponent? [fFdD]
+    ;
+
+Exponent
+    <- [eE] [+]? Digits ;
+
+HexadecimalFloatingPointLiteral
+    <- HexSignificand BinaryExponent [fFdD]? ;
+
+HexSignificand
+    <- ("0x" / "0X") HexDigits? "." HexDigits
+    / HexNumeral "."?
+    ;
+
+HexDigits
+    <- HexDigit ([_]*HexDigit)* ;
+
+HexDigit
+    <- [a-f] / [A-F] / [0-9] ;
+
+BinaryExponent
+    <- [pP] [+]? Digits ;
+
+Digits
+    <- [0-9]([_]*[0-9])* ;
+
+BooleanLiteral
+    <- TRUE
+    / FALSE
+    ;
+
+CharLiteral
+    <- "'" (Escape / !['\\\n\r] _) "'" Spacing
+    ;
+
+StringLiteral
+    <- "\"" (Escape / !["\\\n\r] _)* "\"" Spacing
+    ;
+
+Escape
+    <- "\\" ([btnfr"'\\] / OctalEscape / UnicodeEscape)
+    ;
+
+OctalEscape
+    <- [0-3][0-7][0-7]
+    / [0-7][0-7]
+    / [0-7]
+    ;
+
+UnicodeEscape
+    <- "u"+ HexDigit HexDigit HexDigit HexDigit ;
+
+NullLiteral <- NULL ;
+
+AT              <-   "@"       Spacing ;
+COLONCOLON      <-   "::"      Spacing ;
+COMMA           <-   ","       Spacing ;
+DOT             <-   "."       Spacing ;
+ELLIPSIS        <-   "..."     Spacing ;
+LPAR            <-   "("       Spacing ;
+LBRK            <-   "["       Spacing ;
+RBRK            <-   "]"       Spacing ;
+RPAR            <-   ")"       Spacing ;
+LWING           <-   "{"       Spacing ;
+RWING           <-   "}"       Spacing ;
+SEMI            <-   ";"       Spacing ;
+
+AND             <-   "&"![=&]  Spacing ;
+ANDAND          <-   "&&"      Spacing ;
+ANDEQU          <-   "&="      Spacing ;
+ARROW           <-   "->"      Spacing ;
+BANG            <-   "!" ![=]  Spacing ;
+BSR             <-   ">>>"![=] Spacing ;
+BSREQU          <-   ">>>="    Spacing ;
+COLON           <-   ":" ![:]  Spacing ;
+DEC             <-   "--"      Spacing ;
+DIV             <-   "/" ![=]  Spacing ;
+DIVEQU          <-   "/="      Spacing ;
+EQU             <-   "=" ![=]  Spacing ;
+EQUAL           <-   "=="      Spacing ;
+GE              <-   ">="      Spacing ;
+GT              <-   ">"![=>]  Spacing ;
+HAT             <-   "^"![=]   Spacing ;
+HATEQU          <-   "^="      Spacing ;
+INC             <-   "++"      Spacing ;
+LE              <-   "<="      Spacing ;
+LPOINT          <-   "<"       Spacing ;
+LT              <-   "<"![=<]  Spacing ;
+MINUS           <-   "-"![=>]Spacing ;
+MINUSEQU        <-   "-="      Spacing ;
+MOD             <-   "%"![=]   Spacing ;
+MODEQU          <-   "%="      Spacing ;
+NOTEQUAL        <-   "!="      Spacing ;
+OR              <-   "|"![=|]  Spacing ;
+OREQU           <-   "|="      Spacing ;
+OROR            <-   "||"      Spacing ;
+PLUS            <-   "+"![=+]  Spacing ;
+PLUSEQU         <-   "+="      Spacing ;
+QUERY           <-   "?"       Spacing ;
+RPOINT          <-   ">"       Spacing ;
+SL              <-   "<<"![=]  Spacing ;
+SLEQU           <-   "<<="     Spacing ;
+SR              <-   ">>"![=>] Spacing ;
+SREQU           <-   ">>="     Spacing ;
+STAR            <-   "*"![=]   Spacing ;
+STAREQU         <-   "*="      Spacing ;
+TILDE           <-   "~"       Spacing ;
+
+BasicType
+    <- BYTE
+    / SHORT
+    / INT
+    / LONG
+    / CHAR
+    / FLOAT
+    / DOUBLE
+    / BOOLEAN
+    ;
+
+PrimitiveType
+    <- Annotation* BasicType ;
+
+ReferenceType
+    <- PrimitiveType Dim+
+    / ClassType Dim*
+    ;
+
+ClassType
+    <- Annotation* Identifier TypeArguments?
+          (DOT Annotation* Identifier TypeArguments?)* ;
+
+Type
+    <- PrimitiveType
+    / ClassType
+    ;
+
+ArrayType
+    <- PrimitiveType Dim+
+    / ClassType Dim+
+    ;
+
+TypeVariable
+    <- Annotation* Identifier ;
+
+Dim
+    <- Annotation* LBRK RBRK ;
+
+TypeParameter
+    <- TypeParameterModifier* Identifier TypeBound? ;
+
+TypeParameterModifier
+    <- Annotation ;
+
+TypeBound
+    <- EXTENDS (ClassType AdditionalBound* / TypeVariable) ;
+
+AdditionalBound
+    <- AND ClassType ;
+
+TypeArguments
+    <- LPOINT TypeArgumentList RPOINT ;
+
+TypeArgumentList
+    <- TypeArgument (COMMA TypeArgument)* ;
+
+TypeArgument
+    <- ReferenceType
+    / Wildcard
+    ;
+
+Wildcard
+    <- Annotation* QUERY WildcardBounds? ;
+
+WildcardBounds
+    <- EXTENDS ReferenceType
+    / SUPER ReferenceType
+    ;
+QualIdent
+    <- Identifier (DOT Identifier)* ;
+
+CompilationUnit
+    <- PackageDeclaration? ImportDeclaration* TypeDeclaration* ;
+
+PackageDeclaration
+    <- PackageModifier* PACKAGE Identifier (DOT Identifier)* SEMI ;
+
+PackageModifier
+    <- Annotation ;
+
+ImportDeclaration
+    <- IMPORT STATIC? QualIdent (DOT STAR)? SEMI
+    / SEMI
+    ;
+
+TypeDeclaration
+    <- ClassDeclaration
+    / InterfaceDeclaration
+    / SEMI
+    ;
+
+ClassDeclaration
+    <- NormalClassDeclaration
+    / EnumDeclaration
+    ;
+
+NormalClassDeclaration
+    <- ClassModifier* CLASS Identifier TypeParameters?
+          Superclass? Superinterfaces? ClassBody
+    ;
+
+ClassModifier
+    <- Annotation
+    / PUBLIC
+    / PROTECTED
+    / PRIVATE
+    / ABSTRACT
+    / STATIC
+    / FINAL
+    / STRICTFP
+    ;
+
+TypeParameters
+    <- LPOINT TypeParameterList RPOINT ;
+
+TypeParameterList
+    <- TypeParameter (COMMA TypeParameter)* ;
+
+Superclass
+    <- EXTENDS ClassType ;
+
+Superinterfaces
+    <- IMPLEMENTS InterfaceTypeList ;
+
+InterfaceTypeList
+    <- ClassType (COMMA ClassType)* ;
+
+ClassBody
+    <- LWING ClassBodyDeclaration* RWING ;
+
+ClassBodyDeclaration
+    <- ClassMemberDeclaration
+    / InstanceInitializer
+    / StaticInitializer
+    / ConstructorDeclaration
+    ;
+
+ClassMemberDeclaration
+    <- FieldDeclaration
+    / MethodDeclaration
+    / ClassDeclaration
+    / InterfaceDeclaration
+    / SEMI
+    ;
+
+FieldDeclaration
+    <- FieldModifier* UnannType VariableDeclaratorList SEMI ;
+
+VariableDeclaratorList
+    <- VariableDeclarator (COMMA VariableDeclarator)* ;
+
+VariableDeclarator
+    <- VariableDeclaratorId (EQU VariableInitializer)? ;
+
+VariableDeclaratorId
+    <- Identifier Dim* ;
+
+VariableInitializer
+    <- Expression
+    / ArrayInitializer
+    ;
+
+UnannClassType
+    <- Identifier TypeArguments?
+          (DOT Annotation* Identifier TypeArguments?)*  ;
+
+UnannType
+    <- BasicType Dim*
+    / UnannClassType Dim*
+    ;
+
+FieldModifier
+    <- Annotation
+    / PUBLIC
+    / PROTECTED
+    / PRIVATE
+    / STATIC
+    / FINAL
+    / TRANSIENT
+    / VOLATILE
+    ;
+
+MethodDeclaration
+    <- MethodModifier* MethodHeader MethodBody ;
+
+MethodHeader
+    <- Result MethodDeclarator Throws?
+    / TypeParameters Annotation* Result MethodDeclarator Throws?
+    ;
+
+MethodDeclarator
+    <- Identifier LPAR FormalParameterList? RPAR Dim* ;
+
+FormalParameterList
+    <- (ReceiverParameter / FormalParameter)(COMMA FormalParameter)* ;
+
+FormalParameter
+    <- VariableModifier* UnannType VariableDeclaratorId
+    / VariableModifier* UnannType Annotation* ELLIPSIS VariableDeclaratorId !COMMA
+    ;
+
+VariableModifier
+    <- Annotation
+    / FINAL
+    ;
+
+ReceiverParameter
+    <- VariableModifier* UnannType (Identifier DOT)? THIS ;
+
+Result
+    <- UnannType
+    / VOID
+    ;
+
+MethodModifier
+    <- Annotation
+    / PUBLIC
+    / PROTECTED
+    / PRIVATE
+    / ABSTRACT
+    / STATIC
+    / FINAL
+    / SYNCHRONIZED
+    / NATIVE
+    / STRICTFP
+    ;
+
+Throws
+    <- THROWS ExceptionTypeList ;
+
+ExceptionTypeList
+    <- ExceptionType (COMMA ExceptionType)* ;
+
+ExceptionType
+    <- ClassType
+    / TypeVariable
+    ;
+
+MethodBody
+    <- Block
+    / SEMI
+    ;
+
+InstanceInitializer
+    <- Block ;
+
+StaticInitializer
+    <- STATIC Block ;
+
+ConstructorDeclaration
+    <- ConstructorModifier* ConstructorDeclarator Throws? ConstructorBody ;
+
+ConstructorDeclarator
+    <- TypeParameters? Identifier LPAR FormalParameterList? RPAR ;
+
+ConstructorModifier
+    <- Annotation
+    / PUBLIC
+    / PROTECTED
+    / PRIVATE
+    ;
+
+ConstructorBody
+    <- LWING ExplicitConstructorInvocation? BlockStatements? RWING ;
+
+ExplicitConstructorInvocation
+    <- TypeArguments? THIS Arguments SEMI
+    / TypeArguments? SUPER Arguments SEMI
+    / Primary DOT TypeArguments? SUPER Arguments SEMI
+    / QualIdent DOT TypeArguments? SUPER Arguments SEMI
+    ;
+
+EnumDeclaration
+    <- ClassModifier* ENUM Identifier Superinterfaces? EnumBody ;
+
+EnumBody
+    <- LWING EnumConstantList? COMMA? EnumBodyDeclarations? RWING ;
+
+EnumConstantList
+    <- EnumConstant (COMMA EnumConstant)* ;
+
+EnumConstant
+    <- EnumConstantModifier* Identifier Arguments? ClassBody? ;
+
+EnumConstantModifier
+    <- Annotation ;
+
+EnumBodyDeclarations
+    <- SEMI ClassBodyDeclaration* ;
+
+InterfaceDeclaration
+    <- NormalInterfaceDeclaration
+    / AnnotationTypeDeclaration
+    ;
+
+NormalInterfaceDeclaration
+    <- InterfaceModifier* INTERFACE Identifier TypeParameters?
+          ExtendsInterfaces? InterfaceBody ;
+
+InterfaceModifier
+    <- Annotation
+    / PUBLIC
+    / PROTECTED
+    / PRIVATE
+    / ABSTRACT
+    / STATIC
+    / STRICTFP
+    ;
+
+ExtendsInterfaces
+    <- EXTENDS InterfaceTypeList ;
+
+InterfaceBody
+    <- LWING InterfaceMemberDeclaration* RWING ;
+
+InterfaceMemberDeclaration
+    <- ConstantDeclaration
+    / InterfaceMethodDeclaration
+    / ClassDeclaration
+    / InterfaceDeclaration
+    / SEMI
+    ;
+
+ConstantDeclaration
+    <- ConstantModifier* UnannType VariableDeclaratorList SEMI ;
+
+ConstantModifier
+    <- Annotation
+    / PUBLIC
+    / STATIC
+    / FINAL
+    ;
+
+InterfaceMethodDeclaration
+    <- InterfaceMethodModifier* MethodHeader MethodBody ;
+
+InterfaceMethodModifier
+    <- Annotation
+    / PUBLIC
+    / ABSTRACT
+    / DEFAULT
+    / STATIC
+    / STRICTFP
+    ;
+
+AnnotationTypeDeclaration
+    <- InterfaceModifier* AT INTERFACE Identifier AnnotationTypeBody ;
+
+AnnotationTypeBody
+    <- LWING AnnotationTypeMemberDeclaration* RWING ;
+
+AnnotationTypeMemberDeclaration
+    <- AnnotationTypeElementDeclaration
+    / ConstantDeclaration
+    / ClassDeclaration
+    / InterfaceDeclaration
+    / SEMI
+    ;
+
+AnnotationTypeElementDeclaration
+    <- AnnotationTypeElementModifier* UnannType Identifier LPAR RPAR Dim*
+         DefaultValue? SEMI ;
+
+AnnotationTypeElementModifier
+    <- Annotation
+    / PUBLIC
+    / ABSTRACT
+    ;
+
+DefaultValue
+    <- DEFAULT ElementValue ;
+
+Annotation
+    <- AT
+      ( NormalAnnotation
+      / SingleElementAnnotation
+      / MarkerAnnotation
+      )
+    ;
+
+NormalAnnotation
+    <- QualIdent LPAR ElementValuePairList* RPAR ;
+
+ElementValuePairList
+    <- ElementValuePair (COMMA ElementValuePair)* ;
+
+ElementValuePair
+    <- Identifier EQU ElementValue ;
+
+ElementValue
+    <- ConditionalExpression
+    / ElementValueArrayInitializer
+    / Annotation
+    ;
+
+ElementValueArrayInitializer
+    <- LWING ElementValueList? COMMA? RWING ;
+
+ElementValueList
+    <- ElementValue (COMMA ElementValue)* ;
+
+MarkerAnnotation
+    <- QualIdent ;
+
+SingleElementAnnotation
+    <- QualIdent LPAR ElementValue RPAR ;
+
+ArrayInitializer
+    <- LWING VariableInitializerList? COMMA? RWING ;
+
+VariableInitializerList
+    <- VariableInitializer (COMMA VariableInitializer)* ;
+Block
+    <- LWING BlockStatements? RWING ;
+
+BlockStatements
+    <- BlockStatement BlockStatement* ;
+
+BlockStatement
+    <- LocalVariableDeclarationStatement
+    / ClassDeclaration
+    / Statement
+    ;
+
+LocalVariableDeclarationStatement
+    <- LocalVariableDeclaration SEMI ;
+
+LocalVariableDeclaration
+    <- VariableModifier* UnannType VariableDeclaratorList ;
+
+Statement
+    <- Block
+    / IF ParExpression Statement (ELSE Statement)?
+    / BasicForStatement
+    / EnhancedForStatement
+    / WHILE ParExpression Statement
+    / DO Statement WHILE ParExpression SEMI
+    / TryStatement
+    / SWITCH ParExpression SwitchBlock
+    / SYNCHRONIZED ParExpression Block
+    / RETURN Expression? SEMI
+    / THROW Expression SEMI
+    / BREAK Identifier? SEMI
+    / CONTINUE Identifier? SEMI
+    / ASSERT Expression (COLON Expression)? SEMI
+    / SEMI
+    / StatementExpression SEMI
+    / Identifier COLON Statement
+    ;
+
+StatementExpression
+    <- Assignment
+    / (INC / DEC)(Primary / QualIdent)
+    / (Primary / QualIdent)(INC / DEC)
+    / Primary
+    ;
+
+SwitchBlock
+    <- LWING SwitchBlockStatementGroup* SwitchLabel* RWING ;
+
+SwitchBlockStatementGroup
+    <- SwitchLabels BlockStatements ;
+
+SwitchLabels
+    <- SwitchLabel SwitchLabel* ;
+
+SwitchLabel
+    <- CASE (ConstantExpression / EnumConstantName) COLON
+    / DEFAULT COLON
+    ;
+
+EnumConstantName
+    <- Identifier ;
+
+BasicForStatement
+    <- FOR LPAR ForInit? SEMI Expression? SEMI ForUpdate? RPAR Statement ;
+
+ForInit
+    <- LocalVariableDeclaration
+    / StatementExpressionList
+    ;
+
+ForUpdate
+    <- StatementExpressionList ;
+
+StatementExpressionList
+    <- StatementExpression (COMMA  StatementExpression)* ;
+
+EnhancedForStatement
+    <- FOR LPAR VariableModifier* UnannType VariableDeclaratorId COLON
+          Expression RPAR Statement ;
+
+TryStatement
+    <- TRY
+      ( Block (CatchClause* Finally / CatchClause+)
+      / ResourceSpecification Block CatchClause* Finally?
+      )
+    ;
+
+CatchClause
+    <- CATCH LPAR CatchFormalParameter RPAR Block ;
+
+CatchFormalParameter
+    <- VariableModifier* CatchType VariableDeclaratorId ;
+
+CatchType
+    <- UnannClassType (OR ClassType)* ;
+
+Finally
+    <- FINALLY Block ;
+
+ResourceSpecification
+    <- LPAR ResourceList SEMI? RPAR ;
+
+ResourceList
+    <- Resource (SEMI Resource)* ;
+
+Resource
+    <- VariableModifier* UnannType VariableDeclaratorId EQU Expression ;
+
+Expression
+    <- LambdaExpression
+    / AssignmentExpression
+    ;
+
+Primary
+    <- PrimaryBase PrimaryRest* ;
+
+PrimaryBase
+    <- THIS
+    / Literal
+    / ParExpression
+    / SUPER
+      ( DOT TypeArguments? Identifier Arguments
+      / DOT Identifier
+      / COLONCOLON TypeArguments? Identifier
+      )
+    / NEW
+      ( ClassCreator
+      / ArrayCreator
+      )
+    / QualIdent
+      ( LBRK Expression RBRK
+      / Arguments
+      / DOT
+        ( THIS
+        / NEW ClassCreator
+        / TypeArguments Identifier Arguments
+        / SUPER DOT TypeArguments? Identifier Arguments
+        / SUPER DOT Identifier
+        / SUPER COLONCOLON TypeArguments? Identifier
+        )
+      / (LBRK RBRK)* DOT CLASS
+      / COLONCOLON TypeArguments? Identifier
+      )
+    / VOID DOT CLASS
+    / BasicType (LBRK RBRK)* DOT CLASS
+    / ReferenceType COLONCOLON TypeArguments? Identifier
+    / ClassType COLONCOLON TypeArguments? NEW
+    / ArrayType COLONCOLON NEW
+    ;
+
+PrimaryRest
+    <- DOT
+      ( TypeArguments? Identifier Arguments
+      / Identifier
+      / NEW ClassCreator
+      )
+    / LBRK Expression RBRK
+    / COLONCOLON TypeArguments? Identifier
+    ;
+
+ParExpression
+    <- LPAR Expression RPAR ;
+
+ClassCreator
+    <- TypeArguments? Annotation* ClassTypeWithDiamond
+          Arguments ClassBody? ;
+
+ClassTypeWithDiamond
+    <- Annotation* Identifier TypeArgumentsOrDiamond?
+          (DOT Annotation* Identifier TypeArgumentsOrDiamond?)* ;
+
+TypeArgumentsOrDiamond
+    <- TypeArguments
+    / LPOINT RPOINT !DOT
+    ;
+
+ArrayCreator
+    <- Type DimExpr+ Dim*
+    / Type Dim+ ArrayInitializer
+    ;
+
+DimExpr
+    <- Annotation* LBRK Expression RBRK ;
+
+
+Arguments
+    <- LPAR ArgumentList? RPAR ;
+
+ArgumentList
+    <- Expression (COMMA Expression)* ;
+
+UnaryExpression
+    <- (INC / DEC)(Primary / QualIdent)
+    / PLUS UnaryExpression
+    / MINUS UnaryExpression
+    / UnaryExpressionNotPlusMinus
+    ;
+
+UnaryExpressionNotPlusMinus
+    <- TILDE UnaryExpression
+    / BANG UnaryExpression
+    / CastExpression
+    / (Primary / QualIdent) (INC / DEC)?
+    ;
+
+CastExpression
+    <- LPAR PrimitiveType RPAR UnaryExpression
+    / LPAR ReferenceType AdditionalBound* RPAR LambdaExpression
+    / LPAR ReferenceType AdditionalBound* RPAR UnaryExpressionNotPlusMinus
+    ;
+
+InfixExpression
+    <- UnaryExpression
+          (InfixOperator UnaryExpression)* ;
+
+InfixOperator
+    <- OROR
+    / ANDAND
+    / OR
+    / HAT
+    / AND
+    / EQUAL
+    / NOTEQUAL
+    / LT
+    / GT
+    / LE
+    / GE
+    / SL
+    / SR
+    / BSR
+    / PLUS
+    / MINUS
+    / STAR
+    / DIV
+    / MOD
+    ;
+
+ConditionalExpression
+    <- InfixExpression (QUERY Expression COLON Expression)* ;
+
+AssignmentExpression
+    <- Assignment
+    / ConditionalExpression
+    ;
+
+Assignment
+    <- LeftHandSide AssignmentOperator Expression ;
+
+LeftHandSide
+    <- Primary
+    / QualIdent
+    ;
+
+AssignmentOperator
+    <- EQU
+    / STAREQU
+    / DIVEQU
+    / MODEQU
+    / PLUSEQU
+    / MINUSEQU
+    / SLEQU
+    / SREQU
+    / BSREQU
+    / ANDEQU
+    / HATEQU
+    / OREQU
+    ;
+
+LambdaExpression
+    <- LambdaParameters ARROW LambdaBody ;
+
+LambdaParameters
+    <- Identifier
+    / LPAR FormalParameterList? RPAR
+    / LPAR InferredFormalParameterList RPAR
+    ;
+
+InferredFormalParameterList
+    <- Identifier (COMMA Identifier)* ;
+
+LambdaBody
+    <- Expression
+    / Block
+    ;
+
+ConstantExpression
+    <- Expression ;

--- a/src/test/resources/Java.1.8.peg.-LICENSE.txt
+++ b/src/test/resources/Java.1.8.peg.-LICENSE.txt
@@ -1,0 +1,42 @@
+// The Java 1.8.peg file included in this project is based on the one for
+// Mouse 1.5 - 1.8 by Roman Redziejowski, with some modifications for the
+// pika parser. The copyright notice is included below, as comments had to
+// be removed from the original version.
+
+//===========================================================================
+//
+//  Parsing Expression Grammar of Java 1.8 for Mouse 1.5 - 1.8.
+//  Based on Java Language Specification, Java SE8 Edition, dated 2014-03-03,
+//  obtained from http://docs.oracle.com/javase/specs/jls/se8/html/index.html
+//  and parser code from openjdk.8b132.2014.03.03.
+//
+//---------------------------------------------------------------------------
+//
+//  Copyright (C) 2014
+//  by Roman R Redziejowski(www.romanredz.se).
+//
+//  The author gives unlimited permission to copy and distribute
+//  this file, with or without modifications, as long as this notice
+//  is preserved, and any changes are properly documented.
+//
+//  This file is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//
+//---------------------------------------------------------------------------
+//
+//  Latest update 2014-12-11
+//
+//---------------------------------------------------------------------------
+//  Change log
+//---------------------------------------------------------------------------
+//
+//    2014-10-27 Posted on Internet.
+//    2014-11-01 Corrected NormalInterfaceDeclaration.
+//    2014-11-02 Corrected title comments to JLS 3.10.1 and 3.10.2.
+//               Replaced SimpleQualIdent by Identifier
+//               in ConstructorDeclarator (JLS 8.8).
+//    2014-12-11 Commented out unused definitions: ArrayAccess, FieldAccess,
+//               ClassInstanceCreationExpression, MethodInvocation.
+//
+//===========================================================================

--- a/src/test/resources/MemoTable.java
+++ b/src/test/resources/MemoTable.java
@@ -1,0 +1,246 @@
+//
+// This file is part of the pika parser reference implementation:
+//
+//     https://github.com/lukehutch/pikaparser
+//
+// The pika parsing algorithm is described in the following paper: 
+//
+//     Pika parsing: reformulating packrat parsing as a dynamic programming algorithm solves the left recursion
+//     and error recovery problems. Luke A. D. Hutchison, May 2020.
+//     https://arxiv.org/abs/2005.06444
+//
+// This software is provided under the MIT license:
+//
+// Copyright 2020 Luke A. D. Hutchison
+//  
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+// documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+// and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions
+// of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+// TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+// CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+//
+package pikaparser.memotable;
+
+import pikaparser.clause.Clause;
+import pikaparser.clause.nonterminal.NotFollowedBy;
+import pikaparser.grammar.Grammar;
+import pikaparser.parser.utils.IntervalUnion;
+
+import java.util.AbstractMap.SimpleEntry;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.NavigableMap;
+import java.util.PriorityQueue;
+import java.util.TreeMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/** A memo entry for a specific {@link Clause} at a specific start position. */
+public class MemoTable {
+    /**
+     * A map from clause to startPos to a {@link Match} for the memo entry. (Use concurrent data structures so that
+     * terminals can be memoized in parallel during initialization.)
+     */
+    private Map<MemoKey, Match> memoTable = new HashMap<>();
+
+    /** The grammar. */
+    public Grammar grammar;
+
+    /** The input string. */
+    public String input;
+
+    // -------------------------------------------------------------------------------------------------------------
+
+    /** The number of {@link Match} instances created. */
+    public final AtomicInteger numMatchObjectsCreated = new AtomicInteger();
+
+    /**
+     * The number of {@link Match} instances added to the memo table (some will be overwritten by later matches).
+     */
+    public final AtomicInteger numMatchObjectsMemoized = new AtomicInteger();
+
+    // -------------------------------------------------------------------------------------------------------------
+
+    public MemoTable(Grammar grammar, String input) {
+        this.grammar = grammar;
+        this.input = input;
+    }
+
+    // -------------------------------------------------------------------------------------------------------------
+
+    /** Look up the current best match for a given {@link MemoKey} in the memo table. */
+    public Match lookUpBestMatch(MemoKey memoKey) {
+        // Find current best match in memo table (null if there is no current best match)
+        var bestMatch = memoTable.get(memoKey);
+        if (bestMatch != null) {
+            // If there is a current best match, return it
+            return bestMatch;
+
+        } else if (memoKey.clause instanceof NotFollowedBy) {
+            // Need to match NotFollowedBy top-down
+            return memoKey.clause.match(this, memoKey, input);
+
+        } else if (memoKey.clause.canMatchZeroChars) {
+            // If there is no match in the memo table for this clause, but this clause can match zero characters,
+            // then we need to return a new zero-length match to the parent clause. (This is part of the strategy
+            // for minimizing the number of zero-length matches that are memoized.)
+            // (N.B. this match will not have any subclause matches, which may be unexpected, so conversion of
+            // parse tree to AST should be robust to this.)
+            return new Match(memoKey);
+        }
+        // No match was found in the memo table
+        return null;
+    }
+
+    /**
+     * Add a new {@link Match} to the memo table, if the match is non-null. Schedule seed parent clauses for
+     * matching if the match is non-null or if the parent clause can match zero characters.
+     */
+    public void addMatch(MemoKey memoKey, Match newMatch, PriorityQueue<Clause> priorityQueue) {
+        var matchUpdated = false;
+        if (newMatch != null) {
+            // Track memoization
+            numMatchObjectsCreated.incrementAndGet();
+
+            // Get the memo entry for memoKey if already present; if not, create a new entry
+            var oldMatch = memoTable.get(memoKey);
+
+            // If there is no old match, or the new match is better than the old match
+            if ((oldMatch == null || newMatch.isBetterThan(oldMatch))) {
+                // Store the new match in the memo entry
+                memoTable.put(memoKey, newMatch);
+                matchUpdated = true;
+
+                // Track memoization
+                numMatchObjectsMemoized.incrementAndGet();
+                if (Grammar.DEBUG) {
+                    System.out.println("Setting new best match: " + newMatch.toStringWithRuleNames());
+                }
+            }
+        }
+        for (int i = 0, ii = memoKey.clause.seedParentClauses.size(); i < ii; i++) {
+            var seedParentClause = memoKey.clause.seedParentClauses.get(i);
+            // If there was a valid match, or if there was no match but the parent clause can match
+            // zero characters, schedule the parent clause for matching. (This is part of the strategy
+            // for minimizing the number of zero-length matches that are memoized.)
+            if (matchUpdated || seedParentClause.canMatchZeroChars) {
+                priorityQueue.add(seedParentClause);
+                if (Grammar.DEBUG) {
+                    System.out.println(
+                            "    Following seed parent clause: " + seedParentClause.toStringWithRuleNames());
+                }
+            }
+        }
+        if (Grammar.DEBUG) {
+            System.out.println(
+                    (newMatch != null ? "Matched: " : "Failed to match: ") + memoKey.toStringWithRuleNames());
+        }
+    }
+
+    // -------------------------------------------------------------------------------------------------------------
+
+    /** Get all {@link Match} entries, indexed by clause then start position. */
+    public Map<Clause, NavigableMap<Integer, Match>> getAllNavigableMatches() {
+        var clauseMap = new HashMap<Clause, NavigableMap<Integer, Match>>();
+        memoTable.values().stream().forEach(match -> {
+            var startPosMap = clauseMap.get(match.memoKey.clause);
+            if (startPosMap == null) {
+                startPosMap = new TreeMap<>();
+                clauseMap.put(match.memoKey.clause, startPosMap);
+            }
+            startPosMap.put(match.memoKey.startPos, match);
+        });
+        return clauseMap;
+    }
+
+    /** Get all nonoverlapping {@link Match} entries, indexed by clause then start position. */
+    public Map<Clause, NavigableMap<Integer, Match>> getAllNonOverlappingMatches() {
+        var nonOverlappingClauseMap = new HashMap<Clause, NavigableMap<Integer, Match>>();
+        for (var ent : getAllNavigableMatches().entrySet()) {
+            var clause = ent.getKey();
+            var startPosMap = ent.getValue();
+            var prevEndPos = 0;
+            var nonOverlappingStartPosMap = new TreeMap<Integer, Match>();
+            for (var startPosEnt : startPosMap.entrySet()) {
+                var startPos = startPosEnt.getKey();
+                if (startPos >= prevEndPos) {
+                    var match = startPosEnt.getValue();
+                    nonOverlappingStartPosMap.put(startPos, match);
+                    var endPos = startPos + match.len;
+                    prevEndPos = endPos;
+                }
+            }
+            nonOverlappingClauseMap.put(clause, nonOverlappingStartPosMap);
+        }
+        return nonOverlappingClauseMap;
+    }
+
+    /** Get all {@link Match} entries for the given clause, indexed by start position. */
+    public NavigableMap<Integer, Match> getNavigableMatches(Clause clause) {
+        var treeMap = new TreeMap<Integer, Match>();
+        memoTable.entrySet().stream().forEach(ent -> {
+            if (ent.getKey().clause == clause) {
+                treeMap.put(ent.getKey().startPos, ent.getValue());
+            }
+        });
+        return treeMap;
+    }
+
+    /** Get the {@link Match} entries for all matches of this clause. */
+    public List<Match> getAllMatches(Clause clause) {
+        var matches = new ArrayList<Match>();
+        getNavigableMatches(clause).entrySet().stream().forEach(ent -> matches.add(ent.getValue()));
+        return matches;
+    }
+
+    /**
+     * Get the {@link Match} entries for all nonoverlapping matches of this clause, obtained by greedily matching
+     * from the beginning of the string, then looking for the next match after the end of the current match.
+     */
+    public List<Match> getNonOverlappingMatches(Clause clause) {
+        var matches = getAllMatches(clause);
+        var nonoverlappingMatches = new ArrayList<Match>();
+        for (int i = 0; i < matches.size(); i++) {
+            var match = matches.get(i);
+            var startPos = match.memoKey.startPos;
+            var endPos = startPos + match.len;
+            nonoverlappingMatches.add(match);
+            while (i < matches.size() - 1 && matches.get(i + 1).memoKey.startPos < endPos) {
+                i++;
+            }
+        }
+        return nonoverlappingMatches;
+    }
+
+    /**
+     * Get any syntax errors in the parse, as a map from start position to a tuple, (end position, span of input
+     * string between start position and end position).
+     */
+    public NavigableMap<Integer, Entry<Integer, String>> getSyntaxErrors(String... syntaxCoverageRuleNames) {
+        // Find the range of characters spanned by matches for each of the coverageRuleNames
+        var parsedRanges = new IntervalUnion();
+        for (var coverageRuleName : syntaxCoverageRuleNames) {
+            var rule = grammar.getRule(coverageRuleName);
+            for (var match : getNonOverlappingMatches(rule.labeledClause.clause)) {
+                parsedRanges.addRange(match.memoKey.startPos, match.memoKey.startPos + match.len);
+            }
+        }
+        // Find the inverse of the parsed ranges -- these are the syntax errors
+        var unparsedRanges = parsedRanges.invert(0, input.length()).getNonOverlappingRanges();
+        // Extract the input string span for each unparsed range
+        var syntaxErrorSpans = new TreeMap<Integer, Entry<Integer, String>>();
+        unparsedRanges.entrySet().stream().forEach(ent -> syntaxErrorSpans.put(ent.getKey(),
+                new SimpleEntry<>(ent.getValue(), input.substring(ent.getKey(), ent.getValue()))));
+        return syntaxErrorSpans;
+    }
+}


### PR DESCRIPTION
This is an update of the tests using a modification of Roman Redziejowski's
Java 1.8 PEG grammar for Mouse; the comments had to be removed, since the
pika parser can't handle them. (The copyright info is in the adjoining file.)

The pika parser was not quite able to handle that grammar, so besides the
file with comments removed (in Java.1.8.original_without_comments.peg), there
is also a modified Java.1.8.peg which loads the grammar successfuly, though
it nevertheless is unable to result in a completely sucessful parse of the
accompanying MemoTable.java file. 

Here is what pika parser had trouble with:
--
**1. Missing PEG underscore clause**
```
EOT <- !_ ;
```

This gives:

```
java.lang.IllegalArgumentException: Unknown rule name: _
```

The grammar seems to be using the underscore as a PEG wildcard character (it also appears in one other place in the file). I was able to define an underscore rule to fix the issue, though now it only handles printable ASCII:

```
 _ <- [ -~] ;
```
--
**2. Difficulty defining Java comments in the grammar.**
```
Spacing
    <- ( [ \t\r\n\u000C]+
      / "/*" _*+ "*/"
      / "//" _*+ [\r\n]
      )* ;

    Syntax errors:
        86+5 :     <
        92+3 :  ( 
        126+2 : + 
        147+2 : + 
        155+10 :       )* ;
```

I don't even really understand what this rule is supposed to mean; this is the other
place the underscore was used. However, even defining the underscore rule didn't solve 
the problem. I ultimately tried the following, which allowed the grammar to be 
loaded but which still didn't result in a successful parse of Java comments:
```
    Star <- '*' ;
    NonCloseComment <- [^/] / !Star '/' ;

    Spacing
        <- ( [ \t\r\n]+
        / "/*" NonCloseComment* "*/"
        / "//" [^\r\n]* [\r\n]
        )* ;
```
---
**3. Syntax error for escaped hyphens in character ranges in the grammar** 
Putting escaped hyphens inside a character range doesn't seem to work, even though there is a rule for them:

```
Exponent
    <- [eE] [+\-]? Digits ;

    Syntax errors :
        4638+5 :     <
        4650+3 : [+\
        4654+3 : ]? 
        4663+2 :  ;

BinaryExponent
    <- [pP] [+\-]? Digits ;

    Syntax errors:
        4886+5 :     <
        4898+3 : [+\
        4902+3 : ]? 
        4911+2 :  ;

MINUS           <-   "-"![=\->]Spacing ;

    Syntax errors:
        6613+12 :            <
        6632+4 : ![=\
        6637+2 : >]
        6646+2 :  ;
```

Removing the escaped hyphen fixes the issue, though this prohibits subtraction and negative exponents.

---
**4. Some problem with zero or more of an alternative in the grammar.**
I'm not sure what caused the problem with this one:
```
InfixExpression
    <- UnaryExpression
          ((InfixOperator UnaryExpression) / (INSTANCEOF ReferenceType))* ;

    Syntax errors:
        19020+5 :     <
        19052+1 : (
        19113+4 : )* ;
```
Removing either of the alternatives and one set of parentheses fixes the issue. The modified Java grammar file gets rid of the INSTANCEOF.

---
**5. Unable to handle unicode in the grammar.**
After those fixes, I encountered the following in a second pass:
```
java.lang.IllegalArgumentException: Invalid character: \u
	at pikaparser.parser.utils.StringUtils.unescapeChar(StringUtils.java:100)
	at pikaparser.parser.utils.StringUtils.unescapeString(StringUtils.java:115)
	at pikaparser.grammar.MetaGrammar.parseASTNode(MetaGrammar.java:362)
	at pikaparser.grammar.MetaGrammar.parseRule(MetaGrammar.java:402)
	at pikaparser.grammar.MetaGrammar.parse(MetaGrammar.java:451)
	at pikaparser.EndToEndTest.can_parse_java_example(EndToEndTest.java:111)
```

Fixing this required removing both of the unicode escape characters that appear 
in the grammar file. 

```
    SUB <- "\u001a" ; // (replaced with "\t")
...
    Spacing
            <- ( [ \t\r\n\u000C]+ // (removed unicode SUBSTITUTE character)
            / "/*" _+ "*/"
            / "//" _+ [\r\n]
            )* ;
```
(I also wonder if it might be worth allowing for parsing UTF-32, 
which requires two more hex digits. Also, is it convention to use only the 
lowercase u for escaping unicode?)

---
**6. Syntax errors when parsing the java file.**
After the grammar was loaded I got a heap of syntax errors trying to parse MemoTable.java.
A lot of these are comments, and I wonder how many others will resolve once the issue with 
comments is resolved.

```
SYNTAX ERRORS:

0+1804 : /* * // * // This file is part of the pika parser implementation allowing whitespace-sensitive syntax. It is based * // on the Java reference implementation at: * // * //     https://github.com/lukehutch/pikaparser * // * // The pika parsing algorithm is described in the following paper: * // * //     Pika parsing: reformulating packrat parsing as a dynamic programming algorithm solves the left recursion * //     and error recovery problems. Luke A. D. Hutchison, May 2020. * //     https://arxiv.org/abs/2005.06444 * // * // * // This software is provided under the MIT license: * // * // Copyright (c) 2020 Paul Blair * // Based on pikaparser by Luke Hutchison, also licensed with the MIT license. * // * // Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated * // documentation files (the "Software"), to deal in the Software without restriction, including without limitation * // the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, * // and to permit persons to whom the Software is furnished to do so, subject to the following conditions: * // * // The above copyright notice and this permission notice shall be included in all copies or substantial portions * // of the Software. * // * // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED * // TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL * // THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF * // CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER * // DEALINGS IN THE SOFTWARE. * // * */
2293+359 : /** A memo entry for a specific {@link Clause} at a specific start position. */public class MemoTable {    /**     * A map from clause to startPos to a {@link Match} for the memo entry. (Use concurrent data structures so that     * terminals can be memoized in parallel during initialization.)     */    private Map<MemoKey, Match> memoTable = new HashMap<>()
2657+45 : /** The grammar. */    public Grammar grammar
2707+47 : /** The input string. */    public String input
2759+244 : // -------------------------------------------------------------------------------------------------------------    /** The number of {@link Match} instances created. */    public final AtomicInteger numMatchObjectsCreated = new AtomicInteger()
3008+199 : /**     * The number of {@link Match} instances added to the memo table (some will be overwritten by later matches).     */    public final AtomicInteger numMatchObjectsMemoized = new AtomicInteger()
3212+195 : // -------------------------------------------------------------------------------------------------------------    public MemoTable(Grammar grammar, String input) {        this.grammar = grammar
3416+18 : this.input = input
3439+391 : }    // -------------------------------------------------------------------------------------------------------------    /** Look up the current best match for a given {@link MemoKey} in the memo table. */    public Match lookUpBestMatch(MemoKey memoKey) {        // Find current best match in memo table (null if there is no current best match)        var bestMatch = memoTable.get(memoKey)
3839+110 : if (bestMatch != null) {            // If there is a current best match, return it            return bestMatch
3958+165 : } else if (memoKey.clause instanceof NotFollowedBy) {            // Need to match NotFollowedBy top-down            return memoKey.clause.match(this, memoKey, input)
4132+561 : } else if (memoKey.clause.canMatchZeroChars) {            // If there is no match in the memo table for this clause, but this clause can match zero characters,            // then we need to return a new zero-length match to the parent clause. (This is part of the strategy            // for minimizing the number of zero-length matches that are memoized.)            // (N.B. this match will not have any subclause matches, which may be unexpected, so conversion of            // parse tree to AST should be robust to this.)            return new Match(memoKey)
4702+67 : }        // No match was found in the memo table        return null
4774+342 : }    /**     * Add a new {@link Match} to the memo table, if the match is non-null. Schedule seed parent clauses for     * matching if the match is non-null or if the parent clause can match zero characters.     */    public void addMatch(MemoKey memoKey, Match newMatch, PriorityQueue<Clause> priorityQueue) {        var matchUpdated = false
5125+107 : if (newMatch != null) {            // Track memoization            numMatchObjectsCreated.incrementAndGet()
5245+52 : // Get the memo entry for memoKey if already present
5299+75 : if not, create a new entry            var oldMatch = memoTable.get(memoKey)
5387+250 : // If there is no old match, or the new match is better than the old match            if ((oldMatch == null || newMatch.isBetterThan(oldMatch))) {                // Store the new match in the memo entry                memoTable.put(memoKey, newMatch)
5654+19 : matchUpdated = true
5690+77 : // Track memoization                numMatchObjectsMemoized.incrementAndGet()
5784+121 : if (Grammar.DEBUG) {                    System.out.println("Setting new best match: " + newMatch.toStringWithRuleNames())
5922+91 : }            }        }        for (int i = 0, ii = memoKey.clause.seedParentClauses.size()
6015+6 : i < ii
6023+80 : i++) {            var seedParentClause = memoKey.clause.seedParentClauses.get(i)
6116+392 : // If there was a valid match, or if there was no match but the parent clause can match            // zero characters, schedule the parent clause for matching. (This is part of the strategy            // for minimizing the number of zero-length matches that are memoized.)            if (matchUpdated || seedParentClause.canMatchZeroChars) {                priorityQueue.add(seedParentClause)
6525+167 : if (Grammar.DEBUG) {                    System.out.println(                            "    Following seed parent clause: " + seedParentClause.toStringWithRuleNames())
6709+191 : }            }        }        if (Grammar.DEBUG) {            System.out.println(                    (newMatch != null ? "Matched: " : "Failed to match: ") + memoKey.toStringWithRuleNames())
6909+356 : }    }    // -------------------------------------------------------------------------------------------------------------    /** Get all {@link Match} entries, indexed by clause then start position. */    public Map<Clause, NavigableMap<Integer, Match>> getAllNavigableMatches() {        var clauseMap = new HashMap<Clause, NavigableMap<Integer, Match>>()
7274+111 : memoTable.values().stream().forEach(match -> {            var startPosMap = clauseMap.get(match.memoKey.clause)
7398+71 : if (startPosMap == null) {                startPosMap = new TreeMap<>()
7486+48 : clauseMap.put(match.memoKey.clause, startPosMap)
7547+59 : }            startPosMap.put(match.memoKey.startPos, match)
7615+2 : })
7626+16 : return clauseMap
7647+269 : }    /** Get all nonoverlapping {@link Match} entries, indexed by clause then start position. */    public Map<Clause, NavigableMap<Integer, Match>> getAllNonOverlappingMatches() {        var nonOverlappingClauseMap = new HashMap<Clause, NavigableMap<Integer, Match>>()
7925+90 : for (var ent : getAllNavigableMatches().entrySet()) {            var clause = ent.getKey()
8028+32 : var startPosMap = ent.getValue()
8073+18 : var prevEndPos = 0
8104+61 : var nonOverlappingStartPosMap = new TreeMap<Integer, Match>()
8178+99 : for (var startPosEnt : startPosMap.entrySet()) {                var startPos = startPosEnt.getKey()
8294+83 : if (startPos >= prevEndPos) {                    var match = startPosEnt.getValue()
8398+46 : nonOverlappingStartPosMap.put(startPos, match)
8465+33 : var endPos = startPos + match.len
8519+19 : prevEndPos = endPos
8555+88 : }            }            nonOverlappingClauseMap.put(clause, nonOverlappingStartPosMap)
8652+39 : }        return nonOverlappingClauseMap
8696+217 : }    /** Get all {@link Match} entries for the given clause, indexed by start position. */    public NavigableMap<Integer, Match> getNavigableMatches(Clause clause) {        var treeMap = new TreeMap<Integer, Match>()
8922+160 : memoTable.entrySet().stream().forEach(ent -> {            if (ent.getKey().clause == clause) {                treeMap.put(ent.getKey().startPos, ent.getValue())
9095+11 : }        })
9115+14 : return treeMap
9134+170 : }    /** Get the {@link Match} entries for all matches of this clause. */    public List<Match> getAllMatches(Clause clause) {        var matches = new ArrayList<Match>()
9313+91 : getNavigableMatches(clause).entrySet().stream().forEach(ent -> matches.add(ent.getValue()))
9413+14 : return matches
9432+343 : }    /**     * Get the {@link Match} entries for all nonoverlapping matches of this clause, obtained by greedily matching     * from the beginning of the string, then looking for the next match after the end of the current match.     */    public List<Match> getNonOverlappingMatches(Clause clause) {        var matches = getAllMatches(clause)
9784+50 : var nonoverlappingMatches = new ArrayList<Match>()
9843+14 : for (int i = 0
9859+18 : i < matches.size()
9879+44 : i++) {            var match = matches.get(i)
9936+37 : var startPos = match.memoKey.startPos
9986+33 : var endPos = startPos + match.len
10032+32 : nonoverlappingMatches.add(match)
10077+99 : while (i < matches.size() - 1 && matches.get(i + 1).memoKey.startPos < endPos) {                i++
10189+46 : }        }        return nonoverlappingMatches
10240+429 : }    /**     * Get any syntax errors in the parse, as a map from start position to a tuple, (end position, span of input     * string between start position and end position).     */    public NavigableMap<Integer, Entry<Integer, String>> getSyntaxErrors(String... syntaxCoverageRuleNames) {        // Find the range of characters spanned by matches for each of the coverageRuleNames        var parsedRanges = new IntervalUnion()
10678+110 : for (var coverageRuleName : syntaxCoverageRuleNames) {            var rule = grammar.getRule(coverageRuleName)
10801+168 : for (var match : getNonOverlappingMatches(rule.labeledClause.clause)) {                parsedRanges.addRange(match.memoKey.startPos, match.memoKey.startPos + match.len)
10982+182 : }        }        // Find the inverse of the parsed ranges -- these are the syntax errors        var unparsedRanges = parsedRanges.invert(0, input.length()).getNonOverlappingRanges()
11173+133 : // Extract the input string span for each unparsed range        var syntaxErrorSpans = new TreeMap<Integer, Entry<Integer, String>>()
11315+182 : unparsedRanges.entrySet().stream().forEach(ent -> syntaxErrorSpans.put(ent.getKey(),                new SimpleEntry<>(ent.getValue(), input.substring(ent.getKey(), ent.getValue()))))
11506+23 : return syntaxErrorSpans
11534+2 : }}

Num match objects created: 825799
Num match objects memoized:  785212

```
