### PR TITLE
Some benchmarks for comparing the Java and Kotlin versions of the parser

### DIFF
--- a/src/test/java/pikaparser/Benchmark.java
+++ b/src/test/java/pikaparser/Benchmark.java
@@ -1,0 +1,88 @@
+//
+// This file is part of the pika parser reference implementation:
+//
+//     https://github.com/lukehutch/pikaparser
+//
+// The pika parsing algorithm is described in the following paper:
+//
+//     Pika parsing: reformulating packrat parsing as a dynamic programming algorithm solves the left recursion
+//     and error recovery problems. Luke A. D. Hutchison, May 2020.
+//     https://arxiv.org/abs/2005.06444
+//
+// This software is provided under the MIT license:
+//
+// Copyright 2020 Luke A. D. Hutchison
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+// documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+// and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions
+// of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+// TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+// CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+//
+package pikaparser;
+
+import org.junit.Test;
+import pikaparser.grammar.MetaGrammar;
+import pikaparser.memotable.MemoTable;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.Arrays;
+import java.util.concurrent.Flow;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+public class Benchmark {
+
+    @Test
+    public void arithmetic_example_benchmark() throws IOException, URISyntaxException {
+        final var grammarSpec = TestUtils.loadResourceFile("arithmetic.grammar");
+        final var toBeParsed = TestUtils.loadResourceFile("arithmetic.input");
+
+        final Function<String, MemoTable>  parseGrammarAndParseInput = (String input) -> {
+            final var grammar = MetaGrammar.parse(grammarSpec);
+            return grammar.parse(input);
+        };
+        executeInTimedLoop(parseGrammarAndParseInput, toBeParsed, "arithmetic");
+    }
+
+    @Test
+    public void grammar_loading_benchmark() throws IOException, URISyntaxException {
+        final var grammarSpec = TestUtils.loadResourceFile("Java.1.8.peg");
+        executeInTimedLoop(MetaGrammar::parse, grammarSpec, "java-grammar");
+    }
+
+    @Test
+    public void java_parsing_benchmark() throws IOException, URISyntaxException {
+        final var grammarSpec = TestUtils.loadResourceFile("Java.1.8.peg");
+        final var toBeParsed = TestUtils.loadResourceFile("MemoTable.java");
+
+        final var grammar = MetaGrammar.parse(grammarSpec);
+
+        executeInTimedLoop(grammar::parse, toBeParsed, "java-parse");
+    }
+
+    private static <T> void executeInTimedLoop(Function<String, T> toExecute, String input, String benchmarkName) {
+        final long[] results = new long[100];
+        for(int i = 0; i<100; i++) {
+            final long start = System.nanoTime();
+            toExecute.apply(input);
+            results[i] = System.nanoTime() - start;
+        }
+
+        System.out.println("\n\n\n===================== RESULTS FOR " + benchmarkName + "=====================");
+        System.out.println(
+            Arrays.stream(results)
+                .mapToDouble(nano -> nano / 1_000_000_000.0)
+                .summaryStatistics()
+        );
+    }
+}

--- a/src/test/java/pikaparser/EndToEndTest.java
+++ b/src/test/java/pikaparser/EndToEndTest.java
@@ -29,30 +29,24 @@
 //
 package pikaparser;
 
+import org.junit.Test;
+import pikaparser.clause.Clause;
+import pikaparser.grammar.MetaGrammar;
+import pikaparser.memotable.Match;
+import pikaparser.parser.utils.ParserInfo;
 import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.assertThat;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
-import java.nio.file.Files;
-import java.nio.file.Paths;
-import java.util.Objects;
 //        import pikaparser.parser.utils.ParserInfo;
 
-import org.junit.Test;
-
-import pikaparser.clause.Clause;
-import pikaparser.grammar.MetaGrammar;
-import pikaparser.memotable.Match;
-import pikaparser.parser.utils.ParserInfo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertThat;
+import static pikaparser.TestUtils.loadResourceFile;
 
 public class EndToEndTest {
-    private String loadResourceFile(String filename) throws IOException, URISyntaxException {
-        final var resource = EndToEndTest.class.getClassLoader().getResource(filename);
-        final var resourceUrl = Objects.requireNonNull(resource).toURI();
-        final var lines = Files.readAllLines(Paths.get(resourceUrl));
-        return String.join("", lines);
-    }
 
     @Test
     public void can_parse_arithmetic_example() throws IOException, URISyntaxException {

--- a/src/test/java/pikaparser/TestUtils.java
+++ b/src/test/java/pikaparser/TestUtils.java
@@ -1,0 +1,45 @@
+//
+// This file is part of the pika parser reference implementation:
+//
+//     https://github.com/lukehutch/pikaparser
+//
+// The pika parsing algorithm is described in the following paper:
+//
+//     Pika parsing: reformulating packrat parsing as a dynamic programming algorithm solves the left recursion
+//     and error recovery problems. Luke A. D. Hutchison, May 2020.
+//     https://arxiv.org/abs/2005.06444
+//
+// This software is provided under the MIT license:
+//
+// Copyright 2020 Luke A. D. Hutchison
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+// documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+// and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions
+// of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+// TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+// CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+//
+package pikaparser;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Objects;
+
+public class TestUtils {
+    static String loadResourceFile(String filename) throws IOException, URISyntaxException {
+        final var resource = EndToEndTest.class.getClassLoader().getResource(filename);
+        final var resourceUrl = Objects.requireNonNull(resource).toURI();
+        final var lines = Files.readAllLines(Paths.get(resourceUrl));
+        return String.join("", lines);
+    }
+}


### PR DESCRIPTION
This is pretty unscientific, but I added a test to do a hundred runs of each of the unit tests to gauge performance, so as to compare it with the Kotlin version. I found the performance highly variable, probably because my laptop is doing other things; the only real way to do this would be to put it on a dedicated host. But at least it gives a ballpark idea. The Kotlin version's performance is pretty close to the Java performance, and the variability in the two test runs was much bigger than the difference between the two parsers.

Here are the comparisons:

MacBook Air (Early 2015), 2.2 GHz Intel Core i7, 8 GB 1600 MHz DDR3 RAM
macOS 10.13.6
IntelliJ IDEA 2020.1

Java benchmark:
(Results in seconds)
===================== RESULTS FOR arithmetic=====================
DoubleSummaryStatistics{count=100, sum=1.354179, min=0.004290, average=0.013542, max=0.267944}

===================== RESULTS FOR java-grammar=====================
DoubleSummaryStatistics{count=100, sum=62.343267, min=0.533682, average=0.623433, max=0.881978}

===================== RESULTS FOR java-parse=====================
DoubleSummaryStatistics{count=100, sum=99.580973, min=0.784130, average=0.995810, max=1.311033}

Kotlin benchmark:

(Results in seconds)
===================== RESULTS FOR arithmetic=====================
DoubleSummaryStatistics{count=100, sum=1.394441, min=0.004973, average=0.013944, max=0.252265}

===================== RESULTS FOR java-grammar=====================
DoubleSummaryStatistics{count=100, sum=63.733993, min=0.499645, average=0.637340, max=1.354979}

===================== RESULTS FOR java-parse=====================
DoubleSummaryStatistics{count=100, sum=103.694866, min=0.826100, average=1.036949, max=1.479693}

--- 
Some time later, another comparison:

Second Java benchmark, later:

===================== RESULTS FOR arithmetic=====================
DoubleSummaryStatistics{count=100, sum=1.843691, min=0.004564, average=0.018437, max=0.329759}

===================== RESULTS FOR java-grammar=====================
DoubleSummaryStatistics{count=100, sum=71.491856, min=0.601802, average=0.714919, max=1.022379}

===================== RESULTS FOR java-parse=====================
DoubleSummaryStatistics{count=100, sum=111.961126, min=0.884459, average=1.119611, max=1.496312}

Kotlin benchmark:
===================== RESULTS FOR arithmetic=====================
DoubleSummaryStatistics{count=100, sum=1.788753, min=0.005947, average=0.017888, max=0.192602}

===================== RESULTS FOR java-grammar=====================
DoubleSummaryStatistics{count=100, sum=73.348304, min=0.578634, average=0.733483, max=1.196941}

===================== RESULTS FOR java-parse=====================
DoubleSummaryStatistics{count=100, sum=113.870696, min=0.920826, average=1.138707, max=1.393449}
