### PR TITLE
Test fixes

### DIFF
--- a/src/test/java/pikaparser/TestUtils.java
+++ b/src/test/java/pikaparser/TestUtils.java
@@ -40,6 +40,6 @@ public class TestUtils {
         final var resource = EndToEndTest.class.getClassLoader().getResource(filename);
         final var resourceUrl = Objects.requireNonNull(resource).toURI();
         final var lines = Files.readAllLines(Paths.get(resourceUrl));
-        return String.join("", lines);
+        return String.join("\n", lines);
     }
 }

--- a/src/test/resources/Java.1.8.peg
+++ b/src/test/resources/Java.1.8.peg
@@ -7,8 +7,8 @@ EOT <- !_ ;
 
 Spacing
     <- ( [ \t\r\n]+
-      / "/*" (!"*/" _)* "*/"
-      / "//" (![\r\n] _)*
+      / "/*" (_ !"*/")* "*/"
+      / "//" (_ ![\r\n])* [\r\n]
       )* ;
 
 Identifier  <- !Keyword Letter LetterOrDigit* Spacing ;


### PR DESCRIPTION
Realized that readAllLines removes line separators; fixed
the test for that. Fixed the rule for comments in the Java
PEG grammar, but comments are still not being matched and
coming up as syntax errors.