### PR TITLE
Additional fixes for Java PEG grammar

### DIFF
--- a/src/test/java/pikaparser/EndToEndTest.java
+++ b/src/test/java/pikaparser/EndToEndTest.java
@@ -34,16 +34,18 @@ import pikaparser.clause.Clause;
 import pikaparser.grammar.MetaGrammar;
 import pikaparser.memotable.Match;
 import pikaparser.parser.utils.ParserInfo;
-import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.assertThat;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.util.NavigableMap;
 //        import pikaparser.parser.utils.ParserInfo;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.CoreMatchers.startsWith;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 import static pikaparser.TestUtils.loadResourceFile;
 
 public class EndToEndTest {
@@ -56,11 +58,9 @@ public class EndToEndTest {
         final var input = loadResourceFile("arithmetic.input");
         final var memoTable = grammar.parse(input);
 
-
         final var topRuleName = "Program";
         final String[] recoveryRuleNames = { topRuleName, "Statement" };
         ParserInfo.printParseResult(topRuleName, memoTable, recoveryRuleNames, false);
-
 
         final var allClauses = memoTable.grammar.allClauses;
         assertThat(allClauses.size(), is(27));
@@ -113,6 +113,12 @@ public class EndToEndTest {
         final var syntaxErrors = memoTable.getSyntaxErrors(recoveryRuleNames);
         if (! syntaxErrors.isEmpty()) {
             ParserInfo.printSyntaxErrors(syntaxErrors);
+            fail("Syntax errors were present");
         }
+
+        final Clause topLevelClause = memoTable.grammar.allClauses.get(memoTable.grammar.allClauses.size() - 1);
+        final NavigableMap<Integer, Match> matchedTopLevel = memoTable.getAllNonOverlappingMatches().get(topLevelClause);
+        assertThat("Did not match top level", matchedTopLevel, notNullValue());
+        assertThat(matchedTopLevel.toString(), startsWith("{0=Spacing CompilationUnit (SUB / ()) EOT : 0"));
     }
 }

--- a/src/test/java/pikaparser/TestUtils.java
+++ b/src/test/java/pikaparser/TestUtils.java
@@ -31,15 +31,22 @@ package pikaparser;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
-import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Objects;
+import java.util.Scanner;
 
 public class TestUtils {
-    static String loadResourceFile(String filename) throws IOException, URISyntaxException {
-        final var resource = EndToEndTest.class.getClassLoader().getResource(filename);
-        final var resourceUrl = Objects.requireNonNull(resource).toURI();
-        final var lines = Files.readAllLines(Paths.get(resourceUrl));
-        return String.join("\n", lines);
+    static String loadResourceFile(String filename) throws URISyntaxException, IOException {
+        final var resourceURI = EndToEndTest.class.getClassLoader().getResource(filename).toURI();
+        final Path resourcePath = Paths.get(resourceURI);
+        final var stringBuilder = new StringBuilder();
+
+        // Zero-width lookbehind matches position after the line break, retaining all linebreaks.
+        try(Scanner s=new Scanner(resourcePath).useDelimiter("(?<=\n)|(?!\n)(?<=\r)")) {
+            while(s.hasNext()){
+                stringBuilder.append(s.next());
+            }
+        }
+        return stringBuilder.toString();
     }
 }

--- a/src/test/resources/Java.1.8.peg
+++ b/src/test/resources/Java.1.8.peg
@@ -2,14 +2,14 @@ Compilation
     <- Spacing CompilationUnit SUB? EOT;
 
 _ <- [ -~] ;
-SUB <- "\t" ;
+SUB <- '\u001a' ;
 EOT <- !_ ;
 
 Spacing
-    <- ( [ \t\r\n]+
-      / "/*" (_ !"*/")* "*/"
-      / "//" (_ ![\r\n])* [\r\n]
-      )* ;
+    <- (  [ \t\r\n]+
+       / "/*" ( [^*] / '*' !'/' )* "*/"
+       / "//" [^\n]* '\n'?
+       )* ;
 
 Identifier  <- !Keyword Letter LetterOrDigit* Spacing ;
 
@@ -901,7 +901,7 @@ CastExpression
 
 InfixExpression
     <- UnaryExpression
-          (InfixOperator UnaryExpression)* ;
+          (InfixOperator UnaryExpression / INSTANCEOF ReferenceType)* ;
 
 InfixOperator
     <- OROR


### PR DESCRIPTION
The grammar can now parse MemoTable.java successfully.

Also, the previous fix for readAllLines wasn't preserving a
linebreak at the end of file; this fix to TestUtils preserves
all characters in the file.

There are still a few issues which result in syntax errors using
the original Java PEG grammar, and one additional issue with
respect to parsing comments:

1. With regard to comments, the multiline comment pattern
I submitted previously doesn't seem to work: 

```"/*" (_ !"*/")* "*/"```

I take this as a /* followed by zero or more characters that are not followed by */, followed by */ . 

When I'm debugging an attempted match on a file containing only /* */ I see the following at the space between the asterisks:

```
=============== POSITION: 2 CHARACTER:[ ] ===============
Failed to match: "/*" : 2
Setting new best match: _ <- [ -~] : 2+1
    Following seed parent clause: _ !"*/"
    Following seed parent clause: EOT <- !_
Matched: _ <- [ -~] : 2
    Following seed parent clause: !"*/"
Failed to match: "*/" : 2
    Following seed parent clause: SUB / ()
Failed to match: SUB <- '\t' : 2
Setting new best match: !"*/" : 2+0
Matched: !"*/" : 2
Failed to match: _ !"*/" : 2
Setting new best match: SUB / () : 2+0
    Following seed parent clause: Compilation <- Spacing (SUB / ()) EOT
Matched: SUB / () : 2
    Following seed parent clause: Compilation <- Spacing (SUB / ()) EOT
Failed to match: EOT <- !_ : 2
Failed to match: Compilation <- Spacing (SUB / ()) EOT : 2
Failed to match: Compilation <- Spacing (SUB / ()) EOT : 2
```
From what I see, the space fails to match `_ !"*/"` but somehow it doesn't match the clause `_ !"*/" / ()` which I believe is what the zero-or-more is supposed to turn into.

2. With unicode escapes in the grammar, I was able to put back:

    ```SUB <- '\u001a' ;```

but not:

    ```[ \t\r\n\u000C]+```

which is still a syntax error.

3. The original grammar had the following, which resulted in a syntax error:

```
InfixExpression
    <- UnaryExpression
          ((InfixOperator UnaryExpression) / (INSTANCEOF ReferenceType))* ;
```

removing the extra parentheses, however, works:

```
InfixExpression
    <- UnaryExpression
          (InfixOperator UnaryExpression / INSTANCEOF ReferenceType)* ;
```

4. Finally, the issue with escaped hyphens inside character classes remains. For example, this is still a syntax error:

```
Exponent
    <- [eE] [+\-]? Digits ;
```

Those are all the issues I have found.