### PR TITLE
Updates for tests

### DIFF
--- a/src/test/java/pikaparser/EndToEndTest.java
+++ b/src/test/java/pikaparser/EndToEndTest.java
@@ -60,7 +60,7 @@ public class EndToEndTest {
         // ParserInfo.printParseResult(topRuleName, memoTable, recoveryRuleNames, false);
 
         final var allClauses = memoTable.grammar.allClauses;
-        assertThat(allClauses.size(), is(27));
+        assertThat(allClauses.size(), is(26));
 
         var firstClause = allClauses.get(0);
         var matches = memoTable.getAllMatches(firstClause);
@@ -76,7 +76,7 @@ public class EndToEndTest {
         assertThat(sixteenthMatch.memoKey.startPos, is(21));
         assertThat(sixteenthMatch.memoKey.toStringWithRuleNames(), is("[a-z] : 21"));
 
-        final Clause lastClause = allClauses.get(26);
+        final Clause lastClause = allClauses.get(25);
         matches = memoTable.getAllMatches(lastClause);
 
         final Match topLevelMatch = matches.get(0);

--- a/src/test/resources/Java.1.8.peg
+++ b/src/test/resources/Java.1.8.peg
@@ -1,16 +1,15 @@
 Compilation
     <- Spacing CompilationUnit SUB? EOT;
 
-_ <- [ -~] ;
-SUB <- "\t" ;
+_ <- [\u0000-\uFFFF] ;
+SUB <- '\u001a' ;
 EOT <- !_ ;
-WS <- [ \t\r\n] ;
-ANY <- _ / WS;
+WS <- [ \t\r\n\u000C] ;
 
 Spacing
     <- ( WS+
          / "/**/"
-         / "/*" (ANY !"*/")* _ "*/"
+         / "/*" (_ !"*/")* _ "*/"
          / "//" [^\r\n]*
        )* ;
 
@@ -174,7 +173,7 @@ DecimalFloatingPointLiteral
     ;
 
 Exponent
-    <- [eE] [+]? Digits ;
+    <- [eE] [+\-]? Digits ;
 
 HexadecimalFloatingPointLiteral
     <- HexSignificand BinaryExponent [fFdD]? ;
@@ -191,7 +190,7 @@ HexDigit
     <- [a-f] / [A-F] / [0-9] ;
 
 BinaryExponent
-    <- [pP] [+]? Digits ;
+    <- [pP] [+\-]? Digits ;
 
 Digits
     <- [0-9]([_]*[0-9])* ;
@@ -258,7 +257,7 @@ INC             <-   "++"      Spacing ;
 LE              <-   "<="      Spacing ;
 LPOINT          <-   "<"       Spacing ;
 LT              <-   "<"![=<]  Spacing ;
-MINUS           <-   "-"![=>]Spacing ;
+MINUS           <-   "-"![=\->]Spacing ;
 MINUSEQU        <-   "-="      Spacing ;
 MOD             <-   "%"![=]   Spacing ;
 MODEQU          <-   "%="      Spacing ;
@@ -904,7 +903,7 @@ CastExpression
 
 InfixExpression
     <- UnaryExpression
-          (InfixOperator UnaryExpression)* ;
+          ((InfixOperator UnaryExpression) / (INSTANCEOF ReferenceType))* ;
 
 InfixOperator
     <- OROR
@@ -926,7 +925,6 @@ InfixOperator
     / STAR
     / DIV
     / MOD
-    / INSTANCEOF
     ;
 
 ConditionalExpression


### PR DESCRIPTION
1. This PR makes Java.1.8.peg as close as possible to the original. This involves:

* Defined _ as any Unicode character,
* Reintroduced \u000C as a whitespace character
* Reintroduced hyphens in character classes
* Used the original InfixExpression rule with nested parentheses.

(INSTANCEOF did not need to be listed under InfixOperator as it was
already included with the keywords on line 105.)

The Java.1.8.peg file can be compared against the Java.1.8.original_without_comments.peg file to see that the remaining differences are: 1) defining the underscore character as any Unicode character, and 2) the changes related to Java comments, for which the original rules still don't parse (but also don't seem to make much sense).

2. This PR also updates the can_parse_arithmetic_example test so that it passes.
The recent fixes apparently reduced the number of clauses in the grammar from 
27 to 26, so the test has been adjusted accordingly. The difference in clauses is
as follows -- before today, the rules for E had been:

```
 24 : E[0] <- arith:(E[0] op:('+' / '-') E[1]) / E[1]
 23 : E[0] op:('+' / '-') E[1]
 22 : E[1] <- arith:(E[1] op:('*' / '/') E[2]) / E[2]
 21 : E[1] op:('*' / '/') E[2]
 20 : E[2] <- arith:(op:'-' (E[2] / E[3])) / E[3]
 19 : op:'-' (E[2] / E[3])
 18 : E[2] / E[3]
 17 : E[3] <- (num:[0-9]+ / sym:[a-z]+) / E[4]
 16 : E[4] <- '(' (E[4] / E[0]) ')'
 15 : E[4] / E[0]
```
With the recent changes, the last of these, clause 15, is no longer included.